### PR TITLE
Revert ".github/workflows: Migrate workflows to Blacksmith runners"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: ubuntu-22.04
+          - platform: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
           - platform: macos-latest
             target: x86_64-apple-darwin


### PR DESCRIPTION
Reverts noteban/noteban#3

Blacksmith's windows runners seem less reliable than desired

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR reverts the migration to Blacksmith runners (#3) and returns to using GitHub-hosted runners for CI/CD builds. The changes replace `blacksmith-4vcpu-ubuntu-2404` with `ubuntu-24.04`, `blacksmith-4vcpu-windows-2025` with `windows-latest`, and restore the release job to `ubuntu-latest`.

**Changes:**
- Linux build: `blacksmith-4vcpu-ubuntu-2404` → `ubuntu-24.04`
- Windows build: `blacksmith-4vcpu-windows-2025` → `windows-latest`  
- Release job: `blacksmith-4vcpu-ubuntu-2404` → `ubuntu-latest`

The revert is justified due to reliability concerns with Blacksmith's Windows runners. The workflow remains functionally identical, with all build steps, artifact handling, and release logic preserved. This is a straightforward infrastructure change that should improve build stability.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it's a clean revert to standard GitHub runners
- The changes are minimal and well-understood: reverting runner configuration from Blacksmith to GitHub-hosted runners. No logic changes, workflow structure remains identical, and the motivation is clear (reliability issues). This is a straightforward infrastructure change.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/build.yml | Reverted runner configuration from Blacksmith to GitHub-hosted runners |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as Developer
    participant GH as GitHub Actions
    participant Build as Build Job
    participant Release as Release Job
    
    User->>GH: Push to main or tag
    GH->>Build: Trigger build job
    
    par Linux Build (ubuntu-24.04)
        Build->>Build: Checkout code
        Build->>Build: Setup Node.js & Rust
        Build->>Build: Build Tauri app
        Build->>Build: Upload Linux artifacts
    and macOS x64 Build (macos-latest)
        Build->>Build: Checkout code
        Build->>Build: Setup Node.js & Rust
        Build->>Build: Build Tauri app
        Build->>Build: Upload macOS x64 artifacts
    and macOS ARM Build (macos-latest)
        Build->>Build: Checkout code
        Build->>Build: Setup Node.js & Rust
        Build->>Build: Build Tauri app
        Build->>Build: Upload macOS ARM artifacts
    and Windows Build (windows-latest)
        Build->>Build: Checkout code
        Build->>Build: Setup Node.js & Rust
        Build->>Build: Build Tauri app
        Build->>Build: Upload Windows artifacts
    end
    
    Build->>Release: All builds complete
    
    alt Tag pushed (release)
        Release->>Release: Download all artifacts (ubuntu-latest)
        Release->>Release: Generate latest.json
        Release->>Release: Create GitHub release
        Release->>User: Release published
    else No tag
        Build->>User: Build artifacts available
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->