### PR TITLE
Release v3.2.3

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Your Name <your.email@example.com>
 pkgname=noteban-bin
-pkgver=3.2.2
+pkgver=3.2.3
 pkgrel=1
 pkgdesc="A notes-first app with kanban organization"
 arch=('x86_64')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noteban",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noteban",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.2.0",
         "@codemirror/language-data": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "noteban",
   "private": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "noteban"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "chrono",
  "directories",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noteban"
-version = "3.2.2"
+version = "3.2.3"
 description = "A notes-first app with kanban organization"
 authors = ["you"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Noteban",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "identifier": "dev.th3a.notes",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bumps version to 3.2.3

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR bumps the application version from 3.2.2 to 3.2.3 across all configuration files.

- Consistent version updates across JavaScript (`package.json`, `package-lock.json`), Rust (`Cargo.toml`, `Cargo.lock`), Tauri (`tauri.conf.json`), and AUR packaging (`PKGBUILD`)
- All version fields synchronized to 3.2.3
- No code changes, only version metadata updates

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it only updates version numbers consistently across all configuration files
- All version numbers are correctly and consistently updated to 3.2.3 across all six files (package.json, package-lock.json, Cargo.toml, Cargo.lock, tauri.conf.json, and PKGBUILD). No logic changes or code modifications were made.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Version bumped from 3.2.2 to 3.2.3 |
| package-lock.json | Lock file updated with version 3.2.3 |
| src-tauri/Cargo.toml | Rust package version updated to 3.2.3 |
| src-tauri/Cargo.lock | Rust lock file updated with version 3.2.3 |
| src-tauri/tauri.conf.json | Tauri configuration version updated to 3.2.3 |
| aur/PKGBUILD | AUR package version updated to 3.2.3 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant NPM as package.json
    participant Lock as package-lock.json
    participant Cargo as Cargo.toml
    participant CargoLock as Cargo.lock
    participant Tauri as tauri.conf.json
    participant AUR as PKGBUILD
    
    Dev->>NPM: Update version to 3.2.3
    Dev->>Lock: Update version to 3.2.3
    Dev->>Cargo: Update version to 3.2.3
    Dev->>CargoLock: Update version to 3.2.3
    Dev->>Tauri: Update version to 3.2.3
    Dev->>AUR: Update pkgver to 3.2.3
    
    Note over NPM,AUR: All version fields synchronized to 3.2.3
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->