### PR TITLE
Release v3.2.4

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Your Name <your.email@example.com>
 pkgname=noteban-bin
-pkgver=3.2.3
+pkgver=3.2.4
 pkgrel=1
 pkgdesc="A notes-first app with kanban organization"
 arch=('x86_64')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noteban",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noteban",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.2.0",
         "@codemirror/language-data": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "noteban",
   "private": true,
-  "version": "3.2.3",
+  "version": "3.2.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "noteban"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "chrono",
  "directories",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noteban"
-version = "3.2.3"
+version = "3.2.4"
 description = "A notes-first app with kanban organization"
 authors = ["you"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Noteban",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "identifier": "dev.th3a.notes",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bumps version to 3.2.4

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR bumps the application version from 3.2.3 to 3.2.4 across all relevant configuration files.

- Updated version in `package.json` and `package-lock.json` for the frontend
- Updated version in `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json` for the Tauri backend
- Updated version in `aur/PKGBUILD` for AUR package distribution
- All version references are consistently synchronized to 3.2.4
- This release follows the workflow fix implemented in commit 16c3a7a that addressed release workflow triggering issues

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- All changes are straightforward version number updates across configuration files, with complete consistency across all version references, no code logic changes, and proper sequential version bump from 3.2.3 to 3.2.4
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Version bumped from 3.2.3 to 3.2.4 |
| src-tauri/Cargo.toml | Tauri backend version updated to 3.2.4 |
| src-tauri/tauri.conf.json | Tauri configuration version synchronized to 3.2.4 |
| aur/PKGBUILD | AUR package version updated to 3.2.4 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant PJ as package.json
    participant PL as package-lock.json
    participant CT as Cargo.toml
    participant CL as Cargo.lock
    participant TC as tauri.conf.json
    participant AUR as aur/PKGBUILD
    
    Dev->>PJ: Update version to 3.2.4
    Dev->>PL: Update version to 3.2.4 (2 locations)
    Dev->>CT: Update version to 3.2.4
    Dev->>CL: Update version to 3.2.4
    Dev->>TC: Update version to 3.2.4
    Dev->>AUR: Update pkgver to 3.2.4
    
    Note over Dev,AUR: All version references synchronized to 3.2.4
    Note over Dev,AUR: Release follows workflow fix in commit 16c3a7a
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->