### PR TITLE
Release v3.2.5

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Your Name <your.email@example.com>
 pkgname=noteban-bin
-pkgver=3.2.4
+pkgver=3.2.5
 pkgrel=1
 pkgdesc="A notes-first app with kanban organization"
 arch=('x86_64')

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,7 +5,7 @@
 
 let
   pname = "noteban";
-  version = "3.2.4";
+  version = "3.2.5";
 
   src = fetchurl {
     url = "https://github.com/noteban/noteban/releases/download/v${version}/Noteban_${version}_amd64.AppImage";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noteban",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noteban",
-      "version": "3.2.4",
+      "version": "3.2.5",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.2.0",
         "@codemirror/language-data": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "noteban",
   "private": true,
-  "version": "3.2.4",
+  "version": "3.2.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "noteban"
-version = "3.2.4"
+version = "3.2.5"
 dependencies = [
  "chrono",
  "directories",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noteban"
-version = "3.2.4"
+version = "3.2.5"
 description = "A notes-first app with kanban organization"
 authors = ["you"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Noteban",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "identifier": "dev.th3a.notes",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bumps version to 3.2.5

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR bumps the application version from 3.2.4 to 3.2.5 across all package manifests and lockfiles.

**Key Changes:**
- Updated version in `package.json` and `package-lock.json` for the Node.js project
- Updated version in `src-tauri/Cargo.toml` and `src-tauri/Cargo.lock` for the Rust/Tauri backend
- Updated version in `src-tauri/tauri.conf.json` for the Tauri application configuration
- Updated version in `aur/PKGBUILD` for the Arch User Repository package
- Updated version in `nix/default.nix` for the Nix package

All version changes are consistent across the entire codebase, maintaining synchronization between the frontend, backend, and distribution packages.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it only contains version number updates
- All changes are mechanical version bumps from 3.2.4 to 3.2.5, consistently applied across all package manifests and lockfiles with no logic changes
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Version bumped from 3.2.4 to 3.2.5 |
| src-tauri/Cargo.toml | Rust package version bumped to 3.2.5 |
| src-tauri/tauri.conf.json | Tauri app version updated to 3.2.5 |
| aur/PKGBUILD | AUR package version bumped to 3.2.5 |
| nix/default.nix | Nix package version updated to 3.2.5 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant NPM as package.json
    participant NPMLock as package-lock.json
    participant Cargo as Cargo.toml
    participant CargoLock as Cargo.lock
    participant Tauri as tauri.conf.json
    participant AUR as PKGBUILD
    participant Nix as default.nix
    
    Dev->>NPM: Update version to 3.2.5
    Dev->>NPMLock: Update version to 3.2.5
    Dev->>Cargo: Update version to 3.2.5
    Dev->>CargoLock: Update version to 3.2.5
    Dev->>Tauri: Update version to 3.2.5
    Dev->>AUR: Update pkgver to 3.2.5
    Dev->>Nix: Update version to 3.2.5
    
    Note over NPM,Nix: All version numbers synchronized at 3.2.5
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->