### PR TITLE
Remove CSP rule that breaks CodeMirror in release builds

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,6 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' asset: https://asset.localhost data:; style-src 'self' 'unsafe-inline'",
       "assetProtocol": {
         "enable": true,
         "scope": ["**"]


### PR DESCRIPTION
## Summary
- Remove strict CSP policy from Tauri config that was preventing CodeMirror extensions from functioning properly in release builds
- This fixes markdown rendering issues in the editor (headings, links, checkboxes not rendering correctly)

## Test plan
- [x] Build release with `npm run tauri build`
- [x] Open a note with markdown content
- [x] Verify headings are styled correctly
- [x] Verify links are underlined and clickable with Cmd/Ctrl+click
- [x] Verify checkboxes render and are interactive

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Removes the Content Security Policy (CSP) from Tauri configuration to fix CodeMirror extension rendering issues in release builds. The CSP was blocking CodeMirror's dynamic code features needed for markdown decorations (headings, links, checkboxes).

**Key changes:**
- Removed `csp` directive entirely from `app.security` configuration
- CodeMirror extensions now able to apply dynamic decorations and inline styles

**Security concerns:**
- Removing CSP eliminates protection against XSS and code injection attacks
- The application is now vulnerable to arbitrary script execution if any user-controlled content is rendered without sanitization
- Combined with wildcard asset protocol scope `["**"]`, this creates a broader attack surface

**Recommendation:**
Instead of removing CSP completely, consider adding `'unsafe-eval'` to the policy, which should allow CodeMirror to function while maintaining baseline security protections.

<h3>Confidence Score: 2/5</h3>

- This PR fixes functionality but significantly weakens security by removing all CSP protections
- The change trades security for functionality. While it fixes the immediate CodeMirror rendering issue, removing CSP entirely exposes the application to XSS and code injection attacks. A better solution exists (adding 'unsafe-eval' instead of removing CSP), making this approach suboptimal.
- The tauri.conf.json security configuration needs attention - consider a less permissive approach

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src-tauri/tauri.conf.json | Removes CSP policy to fix CodeMirror rendering issues, but weakens security posture significantly |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Tauri App
    participant CSP
    participant CodeMirror
    participant DOM

    User->>Tauri App: Open note with markdown
    Tauri App->>CodeMirror: Initialize editor with extensions
    
    Note over CSP: Before: CSP blocks dynamic code
    CodeMirror->>CSP: Attempt to use dynamic features
    CSP-->>CodeMirror: ❌ Blocked (script-src 'self')
    CodeMirror-->>DOM: Extensions fail to render
    DOM-->>User: Headings/links/checkboxes not styled
    
    Note over CSP: After: No CSP enforcement
    CodeMirror->>DOM: Apply dynamic decorations & styles
    DOM->>DOM: Execute inline styles via JS
    DOM-->>User: ✅ Full markdown rendering works
    
    Note over Tauri App,DOM: Trade-off: Functionality vs Security
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->