### PR TITLE
Release v3.2.6

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Your Name <your.email@example.com>
 pkgname=noteban-bin
-pkgver=3.2.5
+pkgver=3.2.6
 pkgrel=1
 pkgdesc="A notes-first app with kanban organization"
 arch=('x86_64')

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,7 +5,7 @@
 
 let
   pname = "noteban";
-  version = "3.2.5";
+  version = "3.2.6";
 
   src = fetchurl {
     url = "https://github.com/noteban/noteban/releases/download/v${version}/Noteban_${version}_amd64.AppImage";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noteban",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noteban",
-      "version": "3.2.5",
+      "version": "3.2.6",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.2.0",
         "@codemirror/language-data": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "noteban",
   "private": true,
-  "version": "3.2.5",
+  "version": "3.2.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "noteban"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "chrono",
  "directories",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noteban"
-version = "3.2.5"
+version = "3.2.6"
 description = "A notes-first app with kanban organization"
 authors = ["you"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Noteban",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "identifier": "dev.th3a.notes",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bumps version to 3.2.6

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR bumps the version from 3.2.5 to 3.2.6 across all package manifests and configuration files. The version update is consistent across all 7 files:

- **Frontend**: `package.json` and auto-generated `package-lock.json`
- **Tauri Backend**: `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json`
- **Package Managers**: `aur/PKGBUILD` (Arch User Repository) and `nix/default.nix` (NixOS)

The Nix package hash currently references the v3.2.5 AppImage, which is expected behavior. The repository has an automated GitHub Actions workflow (`update-nix-hash.yml`) that will automatically update the hash after the v3.2.6 release is published and the AppImage becomes available.

No functional code changes were made - this is a pure version bump release preparation.

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with no risk
- The PR contains only version number updates across package manifests and configuration files with no functional code changes. All version numbers are consistently updated to 3.2.6, and the auto-generated lock files are properly synchronized. The Nix hash will be automatically updated by CI after release publication, which is the expected workflow pattern confirmed by examining previous releases.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Version bumped from 3.2.5 to 3.2.6 |
| src-tauri/Cargo.toml | Version bumped from 3.2.5 to 3.2.6 |
| src-tauri/tauri.conf.json | Version bumped from 3.2.5 to 3.2.6 |
| aur/PKGBUILD | Version bumped from 3.2.5 to 3.2.6 for AUR package |
| nix/default.nix | Version bumped from 3.2.5 to 3.2.6; hash will be auto-updated by CI after release |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant PR as Pull Request
    participant Main as Main Branch
    participant CI as CI/CD Pipeline
    participant Release as GitHub Release
    participant Nix as Nix Hash Update

    Dev->>PR: Create PR with version bump to 3.2.6
    Note over PR: Updates 7 files:<br/>- package.json<br/>- src-tauri/Cargo.toml<br/>- src-tauri/tauri.conf.json<br/>- nix/default.nix<br/>- aur/PKGBUILD<br/>- Auto-generated lock files
    PR->>Main: Merge PR
    Main->>CI: Trigger release workflow
    CI->>Release: Create tag v3.2.6 and publish release
    Note over Release: Build and upload AppImage
    Release->>Nix: Trigger update-nix-hash workflow
    Nix->>Nix: Download AppImage
    Nix->>Nix: Calculate SHA256 hash
    Nix->>Main: Commit updated hash to nix/default.nix
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->