### PR TITLE
Attempt fixing EGL issue

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -17,6 +17,24 @@ in
 appimageTools.wrapType2 {
   inherit pname version src;
 
+  # <ID> Graphics/EGL libraries required for WebKit/GTK rendering on NixOS
+  extraPkgs = pkgs: with pkgs; [
+    # Graphics/EGL requirements
+    libGL
+    libdrm
+    mesa
+    vulkan-loader
+    # GTK/WebKit requirements
+    gtk3
+    glib
+    gdk-pixbuf
+    pango
+    cairo
+    atk
+    webkitgtk_4_1
+    libsoup_3
+  ];
+
   extraInstallCommands = ''
     # Install desktop file
     install -Dm644 ${appimageContents}/usr/share/applications/Noteban.desktop \


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added `extraPkgs` parameter to the Nix package definition to include EGL/graphics libraries and GTK/WebKit dependencies required for Tauri's WebKit renderer to function on NixOS.

The change addresses rendering issues by explicitly providing:
- Graphics/EGL requirements: `libGL`, `libdrm`, `mesa`, `vulkan-loader`
- GTK/WebKit requirements: `gtk3`, `glib`, `gdk-pixbuf`, `pango`, `cairo`, `atk`, `webkitgtk_4_1`, `libsoup_3`

This is a common fix for AppImage-wrapped applications on NixOS, where the sandboxed AppImage runtime needs explicit access to system libraries that would normally be available through FHS-compliant directories.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor style issue
- The change follows standard Nix patterns for fixing AppImage EGL issues by adding required dependencies via `extraPkgs`. The libraries included are appropriate for WebKit/GTK rendering. Only issue is a cosmetic `<ID>` tag in a comment.
- No files require special attention beyond the minor style fix suggested

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| nix/default.nix | Added EGL/graphics and GTK/WebKit dependencies via `extraPkgs` to fix rendering issues on NixOS; includes malformed comment tag on line 20 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Nix as Nix Package Manager
    participant AppImage as appimageTools.wrapType2
    participant Runtime as AppImage Runtime
    participant WebKit as WebKit/GTK Renderer
    participant EGL as EGL/Graphics Libraries

    User->>Nix: Install noteban package
    Nix->>AppImage: Call wrapType2 with extraPkgs
    AppImage->>Runtime: Extract and wrap AppImage
    Note over AppImage,Runtime: Include libGL, mesa,<br/>vulkan-loader, gtk3,<br/>webkitgtk_4_1, etc.
    Runtime->>WebKit: Launch Tauri app with WebKit
    WebKit->>EGL: Request graphics context
    EGL-->>WebKit: Provide rendering context
    WebKit-->>User: Display application UI
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->