### PR TITLE
Release v3.2.7

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Your Name <your.email@example.com>
 pkgname=noteban-bin
-pkgver=3.2.6
+pkgver=3.2.7
 pkgrel=1
 pkgdesc="A notes-first app with kanban organization"
 arch=('x86_64')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noteban",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noteban",
-      "version": "3.2.6",
+      "version": "3.2.7",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.2.0",
         "@codemirror/language-data": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "noteban",
   "private": true,
-  "version": "3.2.6",
+  "version": "3.2.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "noteban"
-version = "3.2.6"
+version = "3.2.7"
 dependencies = [
  "chrono",
  "directories",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noteban"
-version = "3.2.6"
+version = "3.2.7"
 description = "A notes-first app with kanban organization"
 authors = ["you"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Noteban",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "identifier": "dev.th3a.notes",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bumps version to 3.2.7

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Bumped version from 3.2.6 to 3.2.7 across all package configuration files.

- Updated version in `package.json` and `package-lock.json` for the Node.js frontend
- Updated version in `src-tauri/Cargo.toml` and `src-tauri/Cargo.lock` for the Rust backend
- Updated version in `src-tauri/tauri.conf.json` for the Tauri application configuration
- Updated version in `aur/PKGBUILD` for the Arch User Repository package

All version changes are consistent and complete. The changes follow the pattern established by the `scripts/bump-version.sh` script, which automates this process.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - simple version bump with consistent changes across all configuration files
- All six files contain only version number updates from 3.2.6 to 3.2.7, with no logic changes or breaking modifications. The changes are consistent across the entire codebase and follow standard release procedures.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Updated version from 3.2.6 to 3.2.7 |
| src-tauri/Cargo.toml | Updated package version from 3.2.6 to 3.2.7 |
| src-tauri/tauri.conf.json | Updated application version from 3.2.6 to 3.2.7 |
| aur/PKGBUILD | Updated AUR package version from 3.2.6 to 3.2.7 |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Script as bump-version.sh
    participant NPM as package.json/lock
    participant Cargo as Cargo.toml/lock
    participant Tauri as tauri.conf.json
    participant AUR as aur/PKGBUILD
    participant Git as Git/GitHub

    Dev->>Script: Run ./scripts/bump-version.sh 3.2.7
    Script->>NPM: Update version to 3.2.7
    Script->>Cargo: Update version to 3.2.7
    Script->>Cargo: cargo update --package noteban
    Script->>Tauri: Update version to 3.2.7
    Script->>NPM: npm install --package-lock-only
    Script->>AUR: Update pkgver to 3.2.7
    Script->>Git: Create release/v3.2.7 branch
    Script->>Git: Commit "Bump version to 3.2.7"
    Script->>Git: Push branch
    Script->>Git: Create PR #25
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->