### PR TITLE
Wrap cache upsert in a transaction

### DIFF
--- a/src-tauri/src/cache/queries.rs
+++ b/src-tauri/src/cache/queries.rs
@@ -1,7 +1,7 @@
 use super::db::CacheDb;
 use crate::commands::notes::{Note, NoteFrontmatter};
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection, Transaction};
+use rusqlite::{params, Transaction};
 use std::collections::HashSet;
 
 #[derive(Debug, Clone)]
@@ -121,7 +121,7 @@ impl CacheDb {
         file_mtime: i64,
         inline_tags: &[String],
     ) -> Result<(), String> {
-        let conn = self
+        let mut conn = self
             .conn
             .lock()
             .map_err(|_| "Cache lock error".to_string())?;


### PR DESCRIPTION
## Summary
- Use a single SQLite transaction for note + tag updates
- Prevent partial tag state on crash/interruption

Fixes #32

## Testing
- Not run (not requested)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wraps the note and tag cache update operations in a single SQLite transaction to ensure atomicity. Previously, if the process crashed or was interrupted between inserting the note and updating its tags, the cache would be left in a partially inconsistent state. Now all operations within `upsert_note` execute atomically - either all changes commit successfully or none do.

The implementation correctly:
- Starts a transaction before any database writes
- Passes the transaction reference through all helper methods (`update_note_tags_internal_tx`, `ensure_tag_exists_tx`)
- Commits the transaction only after all operations succeed
- Properly handles errors at each step with rollback on failure

This is a clean refactoring that addresses the data integrity issue mentioned in #32 without introducing new bugs or breaking changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The changes are well-structured, follow Rust best practices, and directly address a data integrity issue. The transaction handling is correct, error handling is comprehensive, and the refactoring maintains backward compatibility while improving reliability
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src-tauri/src/cache/queries.rs | Wrapped note and tag cache updates in SQLite transaction to ensure atomicity and prevent partial state on crashes |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant CacheDb
    participant SQLite
    
    Client->>CacheDb: upsert_note(note, content_hash, file_mtime, inline_tags)
    CacheDb->>CacheDb: lock connection
    CacheDb->>SQLite: BEGIN TRANSACTION
    
    CacheDb->>SQLite: INSERT OR REPLACE INTO notes
    SQLite-->>CacheDb: note inserted/updated
    
    CacheDb->>CacheDb: update_note_tags_internal_tx(tx, note_id, tags)
    CacheDb->>SQLite: DELETE FROM note_tags WHERE note_id = ?
    SQLite-->>CacheDb: old tags removed
    
    loop for each frontmatter tag
        CacheDb->>CacheDb: ensure_tag_exists_tx(tx, tag)
        CacheDb->>SQLite: INSERT OR IGNORE INTO tags
        SQLite-->>CacheDb: tag ensured
        CacheDb->>SQLite: INSERT OR IGNORE INTO note_tags (source='frontmatter')
        SQLite-->>CacheDb: tag association created
    end
    
    loop for each inline tag
        CacheDb->>CacheDb: ensure_tag_exists_tx(tx, tag)
        CacheDb->>SQLite: INSERT OR IGNORE INTO tags
        SQLite-->>CacheDb: tag ensured
        CacheDb->>SQLite: INSERT OR IGNORE INTO note_tags (source='inline')
        SQLite-->>CacheDb: tag association created
    end
    
    CacheDb->>SQLite: COMMIT TRANSACTION
    SQLite-->>CacheDb: transaction committed
    CacheDb-->>Client: Ok(())
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->