### PR TITLE
Fallback filename when slug is empty

### DIFF
--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -244,7 +244,10 @@ fn slugify(title: &str) -> String {
 fn slugify_or_fallback(title: &str, fallback_id: &str) -> String {
     let slug = slugify(title);
     if slug.is_empty() {
-        format!("untitled-{}", &fallback_id[..fallback_id.len().min(8)])
+        format!(
+            "untitled-{}",
+            fallback_id.chars().take(8).collect::<String>()
+        )
     } else {
         slug
     }


### PR DESCRIPTION
## Summary
- Provide a safe fallback slug when titles have no alphanumeric characters
- Prevent ".md" filename collisions

Fixes #33

## Testing
- Not run (not requested)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes filename collision issues when note titles contain no alphanumeric characters. The new `slugify_or_fallback` function provides a safe fallback (`untitled-{first 8 chars of UUID}`) when `slugify()` returns an empty string, preventing all such notes from being named `.md`. The implementation uses UTF-8 safe character iteration to extract the first 8 characters of the UUID.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-focused, solves a real bug (filename collisions), uses UTF-8 safe operations, and integrates cleanly into existing code paths without breaking changes
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src-tauri/src/commands/notes.rs | Added `slugify_or_fallback` function to prevent empty filename collisions when titles contain no alphanumeric characters. Uses UTF-8 safe character iteration. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CreateNote
    participant SlugifyOrFallback
    participant Slugify
    participant FileSystem
    
    User->>CreateNote: create_note(title: "🎉🎊", ...)
    CreateNote->>SlugifyOrFallback: slugify_or_fallback("🎉🎊", uuid)
    SlugifyOrFallback->>Slugify: slugify("🎉🎊")
    Slugify-->>SlugifyOrFallback: "" (empty string)
    SlugifyOrFallback->>SlugifyOrFallback: Check if slug.is_empty()
    SlugifyOrFallback->>SlugifyOrFallback: Generate "untitled-{first 8 chars of uuid}"
    SlugifyOrFallback-->>CreateNote: "untitled-a1b2c3d4"
    CreateNote->>FileSystem: Write to "untitled-a1b2c3d4.md"
    FileSystem-->>User: Note created successfully
    
    Note over User,FileSystem: Without this fix, all emoji-only titles<br/>would create ".md" files causing collisions
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->