### PR TITLE
Fix tag leaking between profile windows

### DIFF
--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -275,13 +275,23 @@ export const useSettingsStore = create<SettingsState>()(
           p => p.id === currentState.root.activeProfileId
         );
 
+        // If this window's profile was deleted in another window, switch to first available
+        if (!activeProfile) {
+          const fallbackProfile = persisted.root.profiles[0];
+          return {
+            ...currentState,
+            root: persisted.root,
+            settings: fallbackProfile?.settings || currentState.settings,
+          } as SettingsState;
+        }
+
         return {
           ...currentState,
           root: {
             ...persisted.root,
             activeProfileId: currentState.root.activeProfileId,
           },
-          settings: activeProfile?.settings || currentState.settings,
+          settings: activeProfile.settings,
         } as SettingsState;
       },
     }


### PR DESCRIPTION
## Summary
- Prevents cross-window localStorage sync from changing a window's active profile
- Each window now maintains its own `activeProfileId` after initial load
- Profile additions/deletions/renames still sync across windows normally

## Root Cause
Zustand's `persist` middleware syncs state across browser windows via localStorage events. When two windows have different profiles active, any state change in one window would trigger the other window to reload with the wrong profile's data.

## Test plan
- [ ] Open the app with Profile 1
- [ ] Use "Open in New Window" to open Profile 2 in a separate window
- [ ] Confirm each window shows only its own profile's tags
- [ ] Switch profiles in one window - the other window should be unaffected
- [ ] Create a new profile in one window - verify it appears in both windows

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR successfully fixes the tag leaking issue where changes in one profile window would incorrectly appear in another window with a different active profile. The implementation adds a custom `merge` function to Zustand's persist middleware that preserves each window's `activeProfileId` during cross-window localStorage sync events.

**Key Changes:**
- Introduced `hasHydrated` flag to distinguish initial load from subsequent cross-window sync events
- Added custom merge logic that preserves each window's active profile while syncing profile list changes
- Properly handles profile deletion by switching the affected window to the first available profile
- Uses fresh `persisted.root.profiles` data to detect profile existence (addresses previous review feedback)

**Previous Review Feedback - All Addressed:**
- ✓ Now checks `persisted.root.profiles` instead of stale `currentState.root.profiles` for profile existence
- ✓ Profile deletion now correctly switches to first available profile with proper settings fallback
- ✓ `hasHydrated` flag correctly distinguishes initial load from cross-window sync (module-scoped, set once per window lifetime)

The implementation is well-designed with proper defensive programming (optional chaining, fallback values) and correctly handles all edge cases.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The implementation correctly addresses the cross-window sync issue with solid defensive programming. All previous review concerns have been resolved. The logic properly handles initial load, normal sync, and profile deletion scenarios. Code includes appropriate fallbacks and optional chaining for edge cases.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/stores/settingsStore.ts | Added custom merge logic to prevent cross-window localStorage sync from changing a window's active profile, while still syncing profile additions/deletions/renames. All previous review concerns have been addressed. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant W1 as Window 1<br/>(Profile A)
    participant LS as localStorage
    participant W2 as Window 2<br/>(Profile B)
    
    Note over W1,W2: Initial Load
    W1->>LS: Read persisted state
    LS-->>W1: State (activeProfileId: A)
    Note over W1: hasHydrated = true
    
    W2->>LS: Read persisted state
    LS-->>W2: State (activeProfileId: A)
    Note over W2: Override activeProfileId to B<br/>hasHydrated = true
    
    Note over W1,W2: Cross-Window Sync Scenario
    W1->>W1: User adds tag to Profile A
    W1->>LS: Write updated state
    LS->>W2: Storage event triggered
    
    Note over W2: merge() called<br/>hasHydrated = true
    W2->>W2: Find Profile B in persisted.root.profiles
    W2->>W2: Preserve activeProfileId = B<br/>Update Profile B settings from persisted
    Note over W2: Profile A tags NOT visible<br/>Profile B data synced ✓
    
    Note over W1,W2: Profile Deletion Scenario
    W1->>W1: Delete Profile B
    W1->>LS: Write updated state
    LS->>W2: Storage event triggered
    
    Note over W2: merge() called<br/>Profile B not found in persisted
    W2->>W2: Switch to persisted.root.profiles[0]
    Note over W2: Window switches to first<br/>available profile ✓
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->