### PR TITLE
Fix attachment links not updated when note is renamed from editor

### DIFF
--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -518,6 +518,12 @@ pub fn update_note(input: UpdateNoteInput, state: State<AppState>) -> Result<Not
                     }
                     return Err(format!("Failed to rename note: {}", e));
                 }
+
+                // Update attachment references in content to reflect new folder name
+                let old_pattern = format!("{}.attachments/", old_stem);
+                let new_pattern = format!("{}.attachments/", new_stem);
+                note.content = note.content.replace(&old_pattern, &new_pattern);
+
                 current_path = new_path;
 
                 // Remove old path from cache


### PR DESCRIPTION
## Summary
- When a note's title is changed via the H1 heading in the editor, the attachment folder is renamed but image references in the content were not updated
- This adds a content replacement step after a successful rename to update all attachment references from the old folder name to the new one (e.g., `old-title.attachments/` → `new-title.attachments/`)

## Test plan
- [x] Create a note with a title (e.g., "Test Note")
- [x] Add an image attachment to the note
- [x] Change the H1 title in the editor to something different (e.g., "Renamed Note")
- [x] Verify the image still displays correctly (the reference in the markdown should now point to `renamed-note.attachments/`)

Fixes #40

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a bug where attachment image references in markdown content were not updated when a note's title was changed via the H1 heading in the editor. The fix adds a simple string replacement step after the file and attachments folder are successfully renamed.

**Key changes:**
- After successful file rename, the code now replaces all occurrences of `old-stem.attachments/` with `new-stem.attachments/` in the note content
- The replacement happens after the filesystem operations succeed but before the content is written to disk
- Leverages Rust's `String::replace()` method for straightforward pattern replacement

**Analysis:**
- The fix is correctly placed after both the attachments folder and note file have been renamed, ensuring the replacement only happens when the rename operations succeed
- The replacement pattern is specific enough (`{stem}.attachments/`) to avoid false positives in user content
- The existing rollback mechanism for attachments folder rename is preserved
- The modified content is then written atomically to disk, maintaining consistency

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-placed, and addresses a specific bug without introducing complexity. The string replacement is straightforward and happens after successful filesystem operations, maintaining the existing error handling and rollback mechanisms.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src-tauri/src/commands/notes.rs | Adds content replacement to update attachment references after note rename |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Editor
    participant update_note
    participant FileSystem
    
    User->>Editor: Change H1 title
    Editor->>update_note: UpdateNoteInput with new title
    update_note->>update_note: Detect title_changed=true
    update_note->>update_note: Generate old_stem from current filename
    update_note->>update_note: Generate new_stem from slugified title
    
    alt New path is different
        update_note->>FileSystem: Rename attachments folder<br/>(old-stem.attachments → new-stem.attachments)
        FileSystem-->>update_note: Success
        
        update_note->>FileSystem: Rename note file<br/>(old-stem.md → new-stem.md)
        
        alt File rename fails
            FileSystem-->>update_note: Error
            update_note->>FileSystem: Rollback attachments rename
            update_note-->>Editor: Error
        else File rename succeeds
            FileSystem-->>update_note: Success
            update_note->>update_note: Replace content references<br/>(old-stem.attachments/ → new-stem.attachments/)
            update_note->>FileSystem: Atomic write with updated content
            FileSystem-->>update_note: Success
            update_note-->>Editor: Updated note with corrected references
            Editor->>User: Images display correctly
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->