### PR TITLE
Pin Windows builder to windows-2025-vs2026

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
             target: x86_64-apple-darwin
           - platform: macos-latest
             target: aarch64-apple-darwin
-          - platform: windows-latest
+          - platform: windows-2025-vs2026
             target: x86_64-pc-windows-msvc
 
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
## Summary
- GitHub Actions is redirecting `windows-latest` to `windows-2025-vs2026` by June 15, 2026.
- Pin the Windows matrix entry in `.github/workflows/build.yml` to the new label so the migration is explicit rather than implicit.

Closes #102

## Test plan
- [ ] Next CI run on `main` (or this PR) succeeds on the Windows leg using `windows-2025-vs2026`.
- [ ] Resulting `*.exe` / `*.exe.sig` artifacts still upload as `windows-x64`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qf6SgYz1hrg21ucySBFErk)_