### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Noteban is a Tauri v2 desktop app (React 19 + Rust) for markdown note-taking with Kanban organization. It uses npm workspaces with a sub-package at `packages/pie-menu`.
+
+### Tooling
+
+- **Node.js 24** and **Rust stable** are required (see `mise.toml`).
+- The lockfile is `package-lock.json` — use `npm` (not pnpm/yarn).
+- The pie-menu package must be built before the main app can resolve it: `npm run build -w packages/pie-menu`.
+
+### Running the app
+
+Run via Tauri, not the browser — this is a native desktop app:
+
+```sh
+export DISPLAY=:1
+npm run tauri dev
+```
+
+This starts both the Vite dev server (frontend HMR) and the Rust backend with a WebKit webview. The app is never intended to run standalone in a browser.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm install` |
+| Lint | `npm run lint` |
+| TypeScript check | `npx tsc -b` |
+| Build pie-menu | `npm run build -w packages/pie-menu` |
+| Build frontend | `npm run build` |
+| Build Rust backend | `cd src-tauri && cargo build` |
+| Run app (dev) | `npm run tauri dev` |
+
+### Linux system dependencies (Tauri/WebKit)
+
+Required packages on Ubuntu/Debian: `libwebkit2gtk-4.1-dev`, `libgtk-3-dev`, `libsoup-3.0-dev`, `libjavascriptcoregtk-4.1-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`, `libxdo-dev`, `libssl-dev`.
+
+### Editor behavior notes
+
+- When creating a list in the markdown editor, typing `- ` on the first item and pressing Enter will auto-populate subsequent lines with `- `. You only need to type the dash on the first list item.
+- Notes are stored as markdown files with YAML frontmatter in a user-selected directory.
+- SQLite is bundled in the Rust binary (no external DB needed).
+- Ollama (AI tag suggestions) is optional and not required for core functionality.
+
+### Gotchas
+
+- In headless/VM environments, you may see `libEGL warning: DRI3 error` — this is harmless (no GPU acceleration).
+- The `PATH` must have Node 24 before `/exec-daemon/node` (which ships Node 22). Use: `export PATH="/home/ubuntu/.nvm/versions/node/v24.16.0/bin:$PATH"`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,13 @@ Required packages on Ubuntu/Debian: `libwebkit2gtk-4.1-dev`, `libgtk-3-dev`, `li
 - SQLite is bundled in the Rust binary (no external DB needed).
 - Ollama (AI tag suggestions) is optional and not required for core functionality.
 
+### Demo recording guidelines
+
+When recording demo videos of Noteban:
+
+- **Notes must start with a title.** Always type a markdown heading (e.g. `# My Note Title`) as the first line of any new note.
+- **Lists auto-continue.** After typing `- ` on the first list item and pressing Enter, the editor pre-populates subsequent lines with `- `. Do NOT manually type the dash prefix on follow-up list items — just type the text content directly.
+
 ### Gotchas
 
 - In headless/VM environments, you may see `libEGL warning: DRI3 error` — this is harmless (no GPU acceleration).

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "noteban",
       "version": "3.5.2",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@codemirror/lang-markdown": "^6.2.0",
         "@codemirror/language-data": "^6.5.0",
@@ -1262,6 +1265,10 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noteban/pie-menu": {
+      "resolved": "packages/pie-menu",
+      "link": true
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.124.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
@@ -1365,9 +1372,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1385,9 +1389,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1405,9 +1406,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1425,9 +1423,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1445,9 +1440,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1465,9 +1457,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3327,9 +3316,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3351,9 +3337,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3375,9 +3358,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3399,9 +3379,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4235,6 +4212,21 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "packages/pie-menu": {
+      "name": "@noteban/pie-menu",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/react": "^19.2.5",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.1",
+        "typescript": "~5.9.3",
+        "vite": "^8.0.8"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "3.5.2",
   "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/packages/pie-menu/README.md
+++ b/packages/pie-menu/README.md
@@ -1,0 +1,126 @@
+# @noteban/pie-menu
+
+Second Life-style radial (pie) context menu for React.
+
+Touch-first: long-press to open, drag to a sector, release to select. Right-click works on pointer devices. Keyboard `1..n` shortcuts and arrow-key pagination included. Defaults to a black-transparent surface with optional backdrop blur; every colour is exposed as a CSS variable so you can retheme without forking.
+
+## Install
+
+```sh
+npm install @noteban/pie-menu
+```
+
+`react` and `react-dom` are peer dependencies.
+
+## Usage
+
+```tsx
+import { useState } from 'react';
+import { Pencil, Trash2, Copy } from 'lucide-react';
+import { PieMenu, usePieMenu } from '@noteban/pie-menu';
+import '@noteban/pie-menu/style.css';
+
+function FolderRow({ folder }) {
+  const pie = usePieMenu();
+
+  return (
+    <div {...pie.triggerProps}>
+      {folder.name}
+
+      <PieMenu
+        open={pie.open}
+        origin={pie.origin}
+        onClose={pie.close}
+        blur
+        items={[
+          { id: 'rename', label: 'Rename', icon: <Pencil size={18} />, onSelect: () => rename(folder) },
+          { id: 'dup',    label: 'Duplicate', icon: <Copy size={18} />, onSelect: () => duplicate(folder) },
+          { id: 'del',    label: 'Delete', icon: <Trash2 size={18} />, danger: true, onSelect: () => del(folder) },
+        ]}
+      />
+    </div>
+  );
+}
+```
+
+## Props
+
+| Prop | Default | Notes |
+|---|---|---|
+| `open` | required | Whether the menu is rendered. |
+| `origin` | required | Screen coords the menu fans out from. |
+| `items` | required | Sectors, clockwise from 12 o'clock. |
+| `onSelect` | — | Fires alongside the item's own `onSelect`. |
+| `onClose` | required | Esc, outside tap, dead-zone release, selection. |
+| `maxPerPage` | 8 desktop / 4 touch | Sectors per page; extra items paginate. |
+| `wrapPages` | `false` | Wrap Next/Prev past first/last page. |
+| `size` | `220` | Outer diameter in px. |
+| `deadZoneRatio` | `0.25` | Inner cancel radius as fraction of outer. |
+| `openDurationMs` | `140` | Scale/fade animation. |
+| `blur` | `false` | Enables `backdrop-filter: blur(...)` behind the pie. |
+| `blurStrength` | `6` | Blur radius when `blur` is true. |
+| `className` | — | Added to the portal root. |
+| `style` | — | Inline style on the portal root — use this to override CSS variables. |
+| `container` | `document.body` | Portal target. |
+
+## Interaction
+
+| Trigger | Behaviour |
+|---|---|
+| Long-press (≥ `longPressMs`, default 350 ms) | Open at the press point; haptic tick if supported. |
+| Right-click on a pointer device | Open at the cursor. |
+| Drag while open | Highlight the sector under the pointer. |
+| Release on a sector | Select it (or paginate, if it's Prev/Next). |
+| Release in dead-zone or outside outer ring | Cancel. |
+| Horizontal swipe past the outer ring (paginated) | Previous / next page. |
+| `Esc` / outside tap | Cancel. |
+| Number keys `1..n` | Activate sector `n` clockwise from 12. |
+| `ArrowLeft` / `ArrowRight` (paginated) | Previous / next page. |
+
+## Pagination
+
+When `items.length > maxPerPage`:
+
+- 2 pages: **Next** pinned at 6 o'clock on both pages; Next on page 2 wraps to page 1.
+- 3+ pages: **Prev** at 12, **Next** at 6. First page omits Prev, last page omits Next, unless `wrapPages` is `true`.
+- Nav sectors are visually distinct (chevron, muted fill) and only change page.
+- Items hold a stable position within a page across re-opens.
+- A page indicator (`2 / 4`) renders in the dead-zone centre.
+
+## Theming
+
+Override any of these on the menu root via the `style` prop or by targeting `.pie-menu-root`:
+
+```
+--pie-bg                       rgba(0,0,0,0.72)
+--pie-sector-stroke            rgba(255,255,255,0.08)
+--pie-sector-fill              transparent
+--pie-sector-hover-fill        rgba(255,255,255,0.10)
+--pie-sector-active-fill       rgba(255,255,255,0.18)
+--pie-sector-danger-fill       rgba(243,139,168,0.22)
+--pie-text                     rgba(255,255,255,0.92)
+--pie-text-muted               rgba(255,255,255,0.55)
+--pie-text-danger              #f38ba8
+--pie-nav-fill                 rgba(255,255,255,0.04)
+--pie-nav-icon                 rgba(255,255,255,0.55)
+--pie-disabled-opacity         0.35
+--pie-shadow                   0 12px 36px rgba(0,0,0,0.45)
+--pie-open-duration            140ms      (set via `openDurationMs`)
+--pie-blur                     0px        (set via `blurStrength`)
+```
+
+To match a light theme, set lighter values on the consumer side, e.g.:
+
+```tsx
+<PieMenu
+  style={{
+    ['--pie-bg' as never]: 'rgba(20, 20, 28, 0.78)',
+    ['--pie-text' as never]: 'rgba(255, 255, 255, 0.95)',
+  }}
+  /* ... */
+/>
+```
+
+## License
+
+MIT

--- a/packages/pie-menu/package.json
+++ b/packages/pie-menu/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@noteban/pie-menu",
+  "version": "0.1.0",
+  "description": "Second Life-style radial (pie) context menu for React. Touch-first, paginated, themeable.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./style.css": "./dist/style.css"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "vite build && tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.5",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "typescript": "~5.9.3",
+    "vite": "^8.0.8"
+  },
+  "sideEffects": [
+    "*.css"
+  ]
+}

--- a/packages/pie-menu/src/PieMenu.css
+++ b/packages/pie-menu/src/PieMenu.css
@@ -1,0 +1,138 @@
+.pie-menu-root {
+  --pie-bg: rgba(0, 0, 0, 0.72);
+  --pie-sector-stroke: rgba(255, 255, 255, 0.08);
+  --pie-sector-fill: transparent;
+  --pie-sector-hover-fill: rgba(255, 255, 255, 0.10);
+  --pie-sector-active-fill: rgba(255, 255, 255, 0.18);
+  --pie-sector-danger-fill: rgba(243, 139, 168, 0.22);
+  --pie-text: rgba(255, 255, 255, 0.92);
+  --pie-text-muted: rgba(255, 255, 255, 0.55);
+  --pie-text-danger: #f38ba8;
+  --pie-nav-fill: rgba(255, 255, 255, 0.04);
+  --pie-nav-icon: rgba(255, 255, 255, 0.55);
+  --pie-disabled-opacity: 0.35;
+  --pie-shadow: 0 12px 36px rgba(0, 0, 0, 0.45);
+  --pie-open-duration: 140ms;
+  --pie-blur: 0px;
+
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: none;
+}
+
+.pie-menu-root[data-blur='true'] {
+  pointer-events: auto;
+  background: transparent;
+  backdrop-filter: blur(var(--pie-blur));
+  -webkit-backdrop-filter: blur(var(--pie-blur));
+}
+
+.pie-menu-surface {
+  position: absolute;
+  pointer-events: auto;
+  transform-origin: center;
+  filter: drop-shadow(var(--pie-shadow));
+  animation: pie-menu-open var(--pie-open-duration) ease-out;
+}
+
+@keyframes pie-menu-open {
+  from {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.pie-menu-background {
+  fill: var(--pie-bg);
+  stroke: var(--pie-sector-stroke);
+  stroke-width: 1;
+}
+
+.pie-menu-sector {
+  fill: var(--pie-sector-fill);
+  stroke: var(--pie-sector-stroke);
+  stroke-width: 1;
+  cursor: pointer;
+  transition: fill 80ms ease-out;
+}
+
+.pie-menu-sector[data-kind='nav'] {
+  fill: var(--pie-nav-fill);
+  cursor: pointer;
+}
+
+.pie-menu-sector[data-empty='true'] {
+  pointer-events: none;
+  cursor: default;
+}
+
+.pie-menu-sector[data-hover='true'] {
+  fill: var(--pie-sector-hover-fill);
+}
+
+.pie-menu-sector[data-active='true'] {
+  fill: var(--pie-sector-active-fill);
+}
+
+.pie-menu-sector[data-danger='true'][data-hover='true'],
+.pie-menu-sector[data-danger='true'][data-active='true'] {
+  fill: var(--pie-sector-danger-fill);
+}
+
+.pie-menu-sector[data-disabled='true'] {
+  opacity: var(--pie-disabled-opacity);
+  cursor: not-allowed;
+}
+
+.pie-menu-label-group {
+  pointer-events: none;
+  color: var(--pie-text);
+}
+
+.pie-menu-label-group[data-danger='true'] {
+  color: var(--pie-text-danger);
+}
+
+.pie-menu-label-group[data-kind='nav'] {
+  color: var(--pie-nav-icon);
+}
+
+.pie-menu-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.pie-menu-icon > svg {
+  width: 100%;
+  height: 100%;
+}
+
+.pie-menu-label {
+  font-size: 11px;
+  font-weight: 500;
+  text-anchor: middle;
+  dominant-baseline: middle;
+  fill: currentColor;
+  letter-spacing: 0.02em;
+}
+
+.pie-menu-page-indicator {
+  pointer-events: none;
+  text-anchor: middle;
+  dominant-baseline: middle;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  fill: var(--pie-text-muted);
+}

--- a/packages/pie-menu/src/PieMenu.tsx
+++ b/packages/pie-menu/src/PieMenu.tsx
@@ -96,7 +96,9 @@ function PieMenuContent(props: PieMenuProps) {
       setPageIndex((p) => {
         const total = paginated.totalPages;
         const next = p + delta;
-        if (wrapPages) {
+        // 2-page mode always wraps via the Next sector — per spec, page 2's
+        // Next goes back to page 1.
+        if (wrapPages || total === 2) {
           return ((next % total) + total) % total;
         }
         return Math.min(Math.max(next, 0), total - 1);

--- a/packages/pie-menu/src/PieMenu.tsx
+++ b/packages/pie-menu/src/PieMenu.tsx
@@ -1,0 +1,439 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
+
+import type { PieMenuItem, PieMenuProps } from './types';
+import { buildSectors, clampOrigin, hitTestSector } from './geometry';
+import { paginateItems } from './pagination';
+import type { Slot } from './pagination';
+
+import './PieMenu.css';
+
+const DEFAULT_SIZE = 220;
+const DEFAULT_DEAD_ZONE_RATIO = 0.25;
+const DEFAULT_OPEN_DURATION = 140;
+const DEFAULT_BLUR_STRENGTH = 6;
+const SWIPE_THRESHOLD_PX = 60;
+
+function isTouchPrimary(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia?.('(pointer: coarse)').matches ?? false;
+}
+
+function ChevronUp({ size = 16 }: { size?: number }) {
+  return (
+    <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="18 15 12 9 6 15" />
+    </svg>
+  );
+}
+
+function ChevronDown({ size = 16 }: { size?: number }) {
+  return (
+    <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+export function PieMenu(props: PieMenuProps) {
+  if (!props.open) return null;
+  return <PieMenuContent {...props} />;
+}
+
+function PieMenuContent(props: PieMenuProps) {
+  const {
+    origin,
+    items,
+    onSelect,
+    onClose,
+    maxPerPage,
+    wrapPages = false,
+    size = DEFAULT_SIZE,
+    deadZoneRatio = DEFAULT_DEAD_ZONE_RATIO,
+    openDurationMs = DEFAULT_OPEN_DURATION,
+    blur = false,
+    blurStrength = DEFAULT_BLUR_STRENGTH,
+    className,
+    style,
+    container,
+  } = props;
+
+  const resolvedMaxPerPage = maxPerPage ?? (isTouchPrimary() ? 4 : 8);
+  const surfaceRef = useRef<SVGSVGElement | null>(null);
+  const dragStartRef = useRef<{ x: number; y: number } | null>(null);
+
+  const [pageIndex, setPageIndex] = useState(0);
+  const [hoveredSlot, setHoveredSlot] = useState<number | null>(null);
+  const [activeSlot, setActiveSlot] = useState<number | null>(null);
+
+  const paginated = useMemo(
+    () => paginateItems(items, resolvedMaxPerPage, wrapPages),
+    [items, resolvedMaxPerPage, wrapPages],
+  );
+
+  const outerR = size / 2 - 4;
+  const innerR = outerR * deadZoneRatio;
+  const cx = size / 2;
+  const cy = size / 2;
+  const viewportW = typeof window !== 'undefined' ? window.innerWidth : size * 4;
+  const viewportH = typeof window !== 'undefined' ? window.innerHeight : size * 4;
+  const clamped = clampOrigin(origin.x, origin.y, size / 2, viewportW, viewportH);
+
+  const effectivePage = Math.min(pageIndex, Math.max(0, paginated.totalPages - 1));
+  const page = paginated.pages[effectivePage] ?? paginated.pages[0];
+  const slotCount = page?.slots.length ?? 0;
+
+  const sectors = useMemo(
+    () => (slotCount > 0 ? buildSectors(cx, cy, innerR, outerR, slotCount, 0.012) : []),
+    [cx, cy, innerR, outerR, slotCount],
+  );
+
+  const goPage = useCallback(
+    (delta: number) => {
+      setHoveredSlot(null);
+      setActiveSlot(null);
+      setPageIndex((p) => {
+        const total = paginated.totalPages;
+        const next = p + delta;
+        if (wrapPages) {
+          return ((next % total) + total) % total;
+        }
+        return Math.min(Math.max(next, 0), total - 1);
+      });
+    },
+    [paginated.totalPages, wrapPages],
+  );
+
+  const handleActivate = useCallback(
+    (slotIdx: number) => {
+      if (!page) return;
+      const slot = page.slots[slotIdx];
+      if (!slot) return;
+      if (slot.kind === 'item' && slot.item && !slot.item.disabled) {
+        slot.item.onSelect?.();
+        onSelect?.(slot.item);
+        onClose();
+      } else if (slot.kind === 'next') {
+        goPage(1);
+      } else if (slot.kind === 'prev') {
+        goPage(-1);
+      }
+    },
+    [page, onSelect, onClose, goPage],
+  );
+
+  const pointerToLocal = useCallback(
+    (clientX: number, clientY: number) => {
+      const surface = surfaceRef.current;
+      if (!surface) return { dx: 0, dy: 0 };
+      const rect = surface.getBoundingClientRect();
+      const scaleX = size / rect.width;
+      const scaleY = size / rect.height;
+      const localX = (clientX - rect.left) * scaleX;
+      const localY = (clientY - rect.top) * scaleY;
+      return { dx: localX - cx, dy: localY - cy };
+    },
+    [cx, cy, size],
+  );
+
+  const onSurfacePointerDown = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      dragStartRef.current = { x: e.clientX, y: e.clientY };
+      const { dx, dy } = pointerToLocal(e.clientX, e.clientY);
+      const idx = hitTestSector(dx, dy, innerR, outerR, slotCount);
+      setActiveSlot(idx);
+      setHoveredSlot(idx);
+      (e.target as Element).setPointerCapture?.(e.pointerId);
+    },
+    [innerR, outerR, slotCount, pointerToLocal],
+  );
+
+  const onSurfacePointerMove = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      const { dx, dy } = pointerToLocal(e.clientX, e.clientY);
+      const idx = hitTestSector(dx, dy, innerR, outerR, slotCount);
+      setHoveredSlot(idx);
+      if (activeSlot !== null && idx !== null) {
+        setActiveSlot(idx);
+      }
+    },
+    [activeSlot, innerR, outerR, slotCount, pointerToLocal],
+  );
+
+  const onSurfacePointerUp = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      const start = dragStartRef.current;
+      dragStartRef.current = null;
+      const { dx, dy } = pointerToLocal(e.clientX, e.clientY);
+      const idx = hitTestSector(dx, dy, innerR, outerR, slotCount);
+
+      if (paginated.totalPages > 1 && idx === null && start) {
+        const horizDelta = e.clientX - start.x;
+        const vertDelta = e.clientY - start.y;
+        if (
+          Math.abs(horizDelta) > SWIPE_THRESHOLD_PX &&
+          Math.abs(horizDelta) > Math.abs(vertDelta) * 1.5
+        ) {
+          goPage(horizDelta < 0 ? 1 : -1);
+          setActiveSlot(null);
+          return;
+        }
+      }
+
+      setActiveSlot(null);
+      if (idx === null) {
+        onClose();
+        return;
+      }
+      handleActivate(idx);
+    },
+    [
+      handleActivate,
+      goPage,
+      innerR,
+      outerR,
+      slotCount,
+      onClose,
+      pointerToLocal,
+      paginated.totalPages,
+    ],
+  );
+
+  const onSurfacePointerCancel = useCallback(() => {
+    dragStartRef.current = null;
+    setActiveSlot(null);
+    setHoveredSlot(null);
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (!page) return;
+      if (e.key === 'ArrowLeft') {
+        if (paginated.totalPages > 1) {
+          e.preventDefault();
+          goPage(-1);
+        }
+        return;
+      }
+      if (e.key === 'ArrowRight') {
+        if (paginated.totalPages > 1) {
+          e.preventDefault();
+          goPage(1);
+        }
+        return;
+      }
+      const n = Number(e.key);
+      if (!Number.isNaN(n) && n >= 1 && n <= slotCount) {
+        e.preventDefault();
+        handleActivate(n - 1);
+      }
+    };
+
+    const handleOutside = (e: PointerEvent) => {
+      const surface = surfaceRef.current;
+      if (!surface) return;
+      if (surface.contains(e.target as Node)) return;
+      onClose();
+    };
+
+    document.addEventListener('keydown', handleKey);
+    document.addEventListener('pointerdown', handleOutside, true);
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+      document.removeEventListener('pointerdown', handleOutside, true);
+    };
+  }, [onClose, page, slotCount, handleActivate, goPage, paginated.totalPages]);
+
+  if (slotCount === 0) return null;
+
+  const portalTarget =
+    container ?? (typeof document !== 'undefined' ? document.body : null);
+  if (!portalTarget) return null;
+
+  const rootStyle: CSSProperties = {
+    '--pie-open-duration': `${openDurationMs}ms`,
+    '--pie-blur': `${blurStrength}px`,
+    ...style,
+  } as CSSProperties;
+
+  const surfaceStyle: CSSProperties = {
+    left: clamped.x - size / 2,
+    top: clamped.y - size / 2,
+    width: size,
+    height: size,
+  };
+
+  const rootClass = ['pie-menu-root', className].filter(Boolean).join(' ');
+
+  return createPortal(
+    <div
+      className={rootClass}
+      data-blur={blur ? 'true' : 'false'}
+      style={rootStyle}
+      onPointerDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <svg
+        ref={surfaceRef}
+        className="pie-menu-surface"
+        style={surfaceStyle}
+        viewBox={`0 0 ${size} ${size}`}
+        role="menu"
+        aria-label="Pie menu"
+        onPointerDown={onSurfacePointerDown}
+        onPointerMove={onSurfacePointerMove}
+        onPointerUp={onSurfacePointerUp}
+        onPointerCancel={onSurfacePointerCancel}
+        onContextMenu={(e) => e.preventDefault()}
+      >
+        <circle
+          className="pie-menu-background"
+          cx={cx}
+          cy={cy}
+          r={outerR}
+        />
+        {sectors.map((s) => {
+          const slot = page.slots[s.index];
+          return (
+            <SectorShape
+              key={s.index}
+              slot={slot}
+              path={s.path}
+              hovered={hoveredSlot === s.index}
+              active={activeSlot === s.index}
+            />
+          );
+        })}
+        {sectors.map((s) => {
+          const slot = page.slots[s.index];
+          if (!slot || slot.kind === 'empty') return null;
+          return (
+            <SectorLabel
+              key={s.index}
+              slot={slot}
+              x={s.centerX}
+              y={s.centerY}
+              radius={(outerR - innerR) * 0.35}
+            />
+          );
+        })}
+        {paginated.totalPages > 1 && (
+          <text
+            className="pie-menu-page-indicator"
+            x={cx}
+            y={cy}
+          >
+            {effectivePage + 1} / {paginated.totalPages}
+          </text>
+        )}
+      </svg>
+    </div>,
+    portalTarget,
+  );
+}
+
+interface SectorShapeProps {
+  slot: Slot | undefined;
+  path: string;
+  hovered: boolean;
+  active: boolean;
+}
+
+function SectorShape({ slot, path, hovered, active }: SectorShapeProps) {
+  if (!slot) return null;
+  const isItem = slot.kind === 'item';
+  const isNav = slot.kind === 'prev' || slot.kind === 'next';
+  const isEmpty = slot.kind === 'empty';
+  const item = slot.item;
+
+  return (
+    <path
+      d={path}
+      className="pie-menu-sector"
+      data-kind={isNav ? 'nav' : isItem ? 'item' : 'empty'}
+      data-empty={isEmpty ? 'true' : 'false'}
+      data-hover={hovered ? 'true' : 'false'}
+      data-active={active ? 'true' : 'false'}
+      data-danger={item?.danger ? 'true' : 'false'}
+      data-disabled={item?.disabled ? 'true' : 'false'}
+    />
+  );
+}
+
+interface SectorLabelProps {
+  slot: Slot;
+  x: number;
+  y: number;
+  radius: number;
+}
+
+function SectorLabel({ slot, x, y, radius }: SectorLabelProps) {
+  const iconSize = radius * 1.4;
+  const labelOffset = radius * 1.2;
+
+  if (slot.kind === 'prev') {
+    return (
+      <g className="pie-menu-label-group" data-kind="nav">
+        <foreignObject
+          x={x - iconSize / 2}
+          y={y - iconSize / 2}
+          width={iconSize}
+          height={iconSize}
+        >
+          <div className="pie-menu-icon">
+            <ChevronUp size={iconSize} />
+          </div>
+        </foreignObject>
+      </g>
+    );
+  }
+
+  if (slot.kind === 'next') {
+    return (
+      <g className="pie-menu-label-group" data-kind="nav">
+        <foreignObject
+          x={x - iconSize / 2}
+          y={y - iconSize / 2}
+          width={iconSize}
+          height={iconSize}
+        >
+          <div className="pie-menu-icon">
+            <ChevronDown size={iconSize} />
+          </div>
+        </foreignObject>
+      </g>
+    );
+  }
+
+  const item: PieMenuItem | undefined = slot.item;
+  if (!item) return null;
+
+  return (
+    <g
+      className="pie-menu-label-group"
+      data-kind="item"
+      data-danger={item.danger ? 'true' : 'false'}
+    >
+      {item.icon && (
+        <foreignObject
+          x={x - iconSize / 2}
+          y={y - iconSize / 2 - labelOffset / 3}
+          width={iconSize}
+          height={iconSize}
+        >
+          <div className="pie-menu-icon">{item.icon}</div>
+        </foreignObject>
+      )}
+      <text className="pie-menu-label" x={x} y={y + labelOffset / 1.4}>
+        {item.label}
+      </text>
+    </g>
+  );
+}

--- a/packages/pie-menu/src/geometry.ts
+++ b/packages/pie-menu/src/geometry.ts
@@ -1,0 +1,110 @@
+const TAU = Math.PI * 2;
+
+export interface SectorGeometry {
+  /** Sector index within the page (0-based, clockwise from 12 o'clock). */
+  index: number;
+  /** Path used to draw the donut wedge. */
+  path: string;
+  /** Centre point of the sector at mid-radius — where icon / label go. */
+  centerX: number;
+  centerY: number;
+  /** Mid-angle in radians, for transforming child elements. */
+  midAngle: number;
+}
+
+/** Build a donut-wedge path for sector `i` of `total` sectors. */
+export function sectorPath(
+  cx: number,
+  cy: number,
+  innerR: number,
+  outerR: number,
+  total: number,
+  index: number,
+  gap: number = 0,
+): string {
+  const sweep = TAU / total;
+  const halfGap = gap / 2;
+  const a0 = -Math.PI / 2 + index * sweep - sweep / 2 + halfGap;
+  const a1 = -Math.PI / 2 + index * sweep + sweep / 2 - halfGap;
+
+  const largeArc = a1 - a0 > Math.PI ? 1 : 0;
+
+  const x0o = cx + outerR * Math.cos(a0);
+  const y0o = cy + outerR * Math.sin(a0);
+  const x1o = cx + outerR * Math.cos(a1);
+  const y1o = cy + outerR * Math.sin(a1);
+  const x0i = cx + innerR * Math.cos(a0);
+  const y0i = cy + innerR * Math.sin(a0);
+  const x1i = cx + innerR * Math.cos(a1);
+  const y1i = cy + innerR * Math.sin(a1);
+
+  return [
+    `M ${x0o} ${y0o}`,
+    `A ${outerR} ${outerR} 0 ${largeArc} 1 ${x1o} ${y1o}`,
+    `L ${x1i} ${y1i}`,
+    `A ${innerR} ${innerR} 0 ${largeArc} 0 ${x0i} ${y0i}`,
+    'Z',
+  ].join(' ');
+}
+
+/** Compute geometry for every sector on a page. */
+export function buildSectors(
+  cx: number,
+  cy: number,
+  innerR: number,
+  outerR: number,
+  total: number,
+  gap: number = 0,
+): SectorGeometry[] {
+  const sweep = TAU / total;
+  const midR = (innerR + outerR) / 2;
+  const sectors: SectorGeometry[] = [];
+  for (let i = 0; i < total; i++) {
+    const mid = -Math.PI / 2 + i * sweep;
+    sectors.push({
+      index: i,
+      path: sectorPath(cx, cy, innerR, outerR, total, i, gap),
+      centerX: cx + midR * Math.cos(mid),
+      centerY: cy + midR * Math.sin(mid),
+      midAngle: mid,
+    });
+  }
+  return sectors;
+}
+
+/**
+ * Hit-test a pointer (relative to centre) and return the sector index, or
+ * `null` if the pointer is in the dead-zone or beyond the outer ring.
+ */
+export function hitTestSector(
+  dx: number,
+  dy: number,
+  innerR: number,
+  outerR: number,
+  total: number,
+  outerTolerance: number = 24,
+): number | null {
+  const dist = Math.sqrt(dx * dx + dy * dy);
+  if (dist < innerR) return null;
+  if (dist > outerR + outerTolerance) return null;
+
+  const sweep = TAU / total;
+  let theta = Math.atan2(dy, dx) + Math.PI / 2;
+  theta = ((theta % TAU) + TAU) % TAU;
+  return Math.floor((theta + sweep / 2) / sweep) % total;
+}
+
+/** Clamp the menu centre so the bounding circle stays in the viewport. */
+export function clampOrigin(
+  x: number,
+  y: number,
+  radius: number,
+  viewportW: number,
+  viewportH: number,
+  margin: number = 8,
+): { x: number; y: number } {
+  return {
+    x: Math.min(Math.max(x, radius + margin), viewportW - radius - margin),
+    y: Math.min(Math.max(y, radius + margin), viewportH - radius - margin),
+  };
+}

--- a/packages/pie-menu/src/index.ts
+++ b/packages/pie-menu/src/index.ts
@@ -1,0 +1,9 @@
+export { PieMenu } from './PieMenu';
+export { usePieMenu } from './usePieMenu';
+export type {
+  PieMenuItem,
+  PieMenuOrigin,
+  PieMenuProps,
+  UsePieMenuOptions,
+  UsePieMenuReturn,
+} from './types';

--- a/packages/pie-menu/src/pagination.ts
+++ b/packages/pie-menu/src/pagination.ts
@@ -42,7 +42,6 @@ export function paginateItems(
 
   if (n <= max) {
     const slots = items.map((item): Slot => ({ kind: 'item', item }));
-    while (slots.length < n) slots.push({ kind: 'empty' });
     return {
       pages: [{ slots, hasPrev: false, hasNext: false }],
       slotsPerPage: n,

--- a/packages/pie-menu/src/pagination.ts
+++ b/packages/pie-menu/src/pagination.ts
@@ -1,0 +1,113 @@
+import type { PieMenuItem } from './types';
+
+export type SlotKind = 'item' | 'prev' | 'next' | 'empty';
+
+export interface Slot {
+  kind: SlotKind;
+  item?: PieMenuItem;
+}
+
+export interface PieMenuPage {
+  /** Slot for each sector of the page, sized to `slotsPerPage` (= `maxPerPage`). */
+  slots: Slot[];
+  hasPrev: boolean;
+  hasNext: boolean;
+}
+
+export interface PaginatedMenu {
+  pages: PieMenuPage[];
+  /** Number of sectors rendered per page (always equal to `maxPerPage`). */
+  slotsPerPage: number;
+  totalPages: number;
+}
+
+/**
+ * Distribute `items` across one or more pages.
+ *
+ * - <= maxPerPage items: 1 page, no nav sectors.
+ * - 2 pages: Next pinned at 6 o'clock on both pages; Next wraps page-2 -> page-1.
+ * - >2 pages: Prev pinned at 12, Next pinned at 6. First page omits Prev,
+ *   last page omits Next, unless `wrapPages` is true.
+ *
+ * Items keep stable in-page positions across reopens because slot
+ * assignment is purely a function of (pageIndex, slotIndex, item ordering).
+ */
+export function paginateItems(
+  items: PieMenuItem[],
+  maxPerPage: number,
+  wrapPages: boolean = false,
+): PaginatedMenu {
+  const n = items.length;
+  const max = Math.max(3, maxPerPage);
+
+  if (n <= max) {
+    const slots = items.map((item): Slot => ({ kind: 'item', item }));
+    while (slots.length < n) slots.push({ kind: 'empty' });
+    return {
+      pages: [{ slots, hasPrev: false, hasNext: false }],
+      slotsPerPage: n,
+      totalPages: 1,
+    };
+  }
+
+  const capacity2 = 2 * (max - 1);
+  let totalPages: number;
+  if (n <= capacity2 && !wrapPages) {
+    totalPages = 2;
+  } else if (wrapPages) {
+    totalPages = Math.ceil(n / (max - 2));
+    if (totalPages < 2) totalPages = 2;
+  } else {
+    const remaining = n - 2 * (max - 1);
+    const middle = Math.ceil(remaining / (max - 2));
+    totalPages = 2 + Math.max(0, middle);
+  }
+
+  const pages: PieMenuPage[] = [];
+  let cursor = 0;
+
+  for (let p = 0; p < totalPages; p++) {
+    const isFirst = p === 0;
+    const isLast = p === totalPages - 1;
+
+    let hasPrev: boolean;
+    let hasNext: boolean;
+    if (wrapPages) {
+      hasPrev = totalPages > 1;
+      hasNext = totalPages > 1;
+    } else if (totalPages === 2) {
+      hasPrev = false;
+      hasNext = true;
+    } else {
+      hasPrev = !isFirst;
+      hasNext = !isLast;
+    }
+
+    const navCount = (hasPrev ? 1 : 0) + (hasNext ? 1 : 0);
+    const itemSlots = max - navCount;
+    const take = Math.min(itemSlots, n - cursor);
+    const pageItems = items.slice(cursor, cursor + take);
+    cursor += take;
+
+    const slots: Slot[] = new Array<Slot>(max).fill({ kind: 'empty' }).map(
+      (): Slot => ({ kind: 'empty' }),
+    );
+
+    const prevSlot = 0;
+    const nextSlot = Math.floor(max / 2);
+
+    if (hasPrev) slots[prevSlot] = { kind: 'prev' };
+    if (hasNext) slots[nextSlot] = { kind: 'next' };
+
+    let itemIdx = 0;
+    for (let s = 0; s < max && itemIdx < pageItems.length; s++) {
+      if (slots[s].kind !== 'empty') continue;
+      slots[s] = { kind: 'item', item: pageItems[itemIdx] };
+      itemIdx++;
+    }
+
+    pages.push({ slots, hasPrev, hasNext });
+  }
+
+  return { pages, slotsPerPage: max, totalPages };
+}

--- a/packages/pie-menu/src/types.ts
+++ b/packages/pie-menu/src/types.ts
@@ -1,0 +1,85 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+export interface PieMenuItem {
+  /** Stable identifier; also used as the React key. */
+  id: string;
+  /** Visible label rendered inside the sector. */
+  label: string;
+  /** Optional icon node (typically a `lucide-react` icon). */
+  icon?: ReactNode;
+  /** Marks the item as destructive — picks up the danger accent. */
+  danger?: boolean;
+  /** Disables the sector; release will not fire `onSelect`. */
+  disabled?: boolean;
+  /** Per-item selection handler. The top-level `onSelect` runs too. */
+  onSelect?: () => void;
+}
+
+export interface PieMenuOrigin {
+  x: number;
+  y: number;
+}
+
+export interface PieMenuProps {
+  /** Whether the menu is currently open. */
+  open: boolean;
+  /** Screen coordinates the menu should fan out from. */
+  origin: PieMenuOrigin;
+  /** Items rendered as sectors, in clockwise order from 12 o'clock. */
+  items: PieMenuItem[];
+  /** Called when an item is selected. */
+  onSelect?: (item: PieMenuItem) => void;
+  /** Called when the menu should close (Esc, outside tap, dead-zone release, selection). */
+  onClose: () => void;
+
+  /** Max sectors per page. Defaults: 8 on pointer devices, 4 on touch. */
+  maxPerPage?: number;
+  /** Wrap Next/Prev around the ends instead of disabling them on first/last page. */
+  wrapPages?: boolean;
+  /** Overall diameter in pixels. Default: 220. */
+  size?: number;
+  /** Dead-zone radius as a fraction of outer radius (0-1). Default: 0.25. */
+  deadZoneRatio?: number;
+  /** Long-press / open animation duration in ms. Default: 140. */
+  openDurationMs?: number;
+  /** When true, applies a backdrop-filter blur behind the pie. Default: false. */
+  blur?: boolean;
+  /** Backdrop blur strength in px when `blur` is true. Default: 6. */
+  blurStrength?: number;
+  /** Extra class applied to the root portal element. */
+  className?: string;
+  /** Inline style overrides on the root element. Use CSS custom properties to retheme. */
+  style?: CSSProperties;
+  /** Portal target. Defaults to `document.body`. */
+  container?: HTMLElement | null;
+}
+
+export interface UsePieMenuOptions {
+  /** Long-press threshold in ms for touch. Default: 350. */
+  longPressMs?: number;
+  /** Allowed movement in px before a long-press is cancelled. Default: 8. */
+  movementToleranceX?: number;
+  /** Open the pie on right-click (contextmenu). Default: true. */
+  enableContextMenu?: boolean;
+  /** Open the pie on long-press for touch. Default: true. */
+  enableLongPress?: boolean;
+  /** Fire a haptic tick on open if `navigator.vibrate` exists. Default: true. */
+  haptic?: boolean;
+}
+
+export interface UsePieMenuReturn {
+  open: boolean;
+  origin: PieMenuOrigin;
+  /** Spread on the trigger element to wire pointer / touch / context handlers. */
+  triggerProps: {
+    onContextMenu: (e: React.MouseEvent) => void;
+    onPointerDown: (e: React.PointerEvent) => void;
+    onPointerMove: (e: React.PointerEvent) => void;
+    onPointerUp: (e: React.PointerEvent) => void;
+    onPointerCancel: (e: React.PointerEvent) => void;
+  };
+  /** Programmatically open the menu at a given screen position. */
+  openAt: (origin: PieMenuOrigin) => void;
+  /** Programmatically close the menu. */
+  close: () => void;
+}

--- a/packages/pie-menu/src/types.ts
+++ b/packages/pie-menu/src/types.ts
@@ -57,8 +57,8 @@ export interface PieMenuProps {
 export interface UsePieMenuOptions {
   /** Long-press threshold in ms for touch. Default: 350. */
   longPressMs?: number;
-  /** Allowed movement in px before a long-press is cancelled. Default: 8. */
-  movementToleranceX?: number;
+  /** Allowed movement (px, either axis) before a long-press is cancelled. Default: 8. */
+  movementTolerance?: number;
   /** Open the pie on right-click (contextmenu). Default: true. */
   enableContextMenu?: boolean;
   /** Open the pie on long-press for touch. Default: true. */

--- a/packages/pie-menu/src/usePieMenu.ts
+++ b/packages/pie-menu/src/usePieMenu.ts
@@ -1,0 +1,117 @@
+import { useCallback, useRef, useState } from 'react';
+import type { PieMenuOrigin, UsePieMenuOptions, UsePieMenuReturn } from './types';
+
+const DEFAULT_LONG_PRESS_MS = 350;
+const DEFAULT_MOVE_TOLERANCE = 8;
+
+export function usePieMenu(options: UsePieMenuOptions = {}): UsePieMenuReturn {
+  const {
+    longPressMs = DEFAULT_LONG_PRESS_MS,
+    movementToleranceX = DEFAULT_MOVE_TOLERANCE,
+    enableContextMenu = true,
+    enableLongPress = true,
+    haptic = true,
+  } = options;
+
+  const [open, setOpen] = useState(false);
+  const [origin, setOrigin] = useState<PieMenuOrigin>({ x: 0, y: 0 });
+
+  const longPressTimer = useRef<number | null>(null);
+  const pointerStart = useRef<{ x: number; y: number; id: number } | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (longPressTimer.current !== null) {
+      window.clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }, []);
+
+  const openAt = useCallback(
+    (next: PieMenuOrigin) => {
+      setOrigin(next);
+      setOpen(true);
+      if (haptic && typeof navigator !== 'undefined' && navigator.vibrate) {
+        navigator.vibrate?.(8);
+      }
+    },
+    [haptic],
+  );
+
+  const close = useCallback(() => {
+    clearTimer();
+    setOpen(false);
+  }, [clearTimer]);
+
+  const onContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      if (!enableContextMenu) return;
+      e.preventDefault();
+      openAt({ x: e.clientX, y: e.clientY });
+    },
+    [enableContextMenu, openAt],
+  );
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (!enableLongPress) return;
+      if (e.pointerType !== 'touch' && e.pointerType !== 'pen') return;
+      pointerStart.current = { x: e.clientX, y: e.clientY, id: e.pointerId };
+      clearTimer();
+      const startX = e.clientX;
+      const startY = e.clientY;
+      longPressTimer.current = window.setTimeout(() => {
+        longPressTimer.current = null;
+        openAt({ x: startX, y: startY });
+      }, longPressMs);
+    },
+    [enableLongPress, longPressMs, clearTimer, openAt],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      const start = pointerStart.current;
+      if (!start) return;
+      if (start.id !== e.pointerId) return;
+      const dx = Math.abs(e.clientX - start.x);
+      const dy = Math.abs(e.clientY - start.y);
+      if (dx > movementToleranceX || dy > movementToleranceX) {
+        clearTimer();
+      }
+    },
+    [clearTimer, movementToleranceX],
+  );
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      if (pointerStart.current?.id === e.pointerId) {
+        pointerStart.current = null;
+      }
+      clearTimer();
+    },
+    [clearTimer],
+  );
+
+  const onPointerCancel = useCallback(
+    (e: React.PointerEvent) => {
+      if (pointerStart.current?.id === e.pointerId) {
+        pointerStart.current = null;
+      }
+      clearTimer();
+    },
+    [clearTimer],
+  );
+
+  return {
+    open,
+    origin,
+    triggerProps: {
+      onContextMenu,
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel,
+    },
+    openAt,
+    close,
+  };
+}

--- a/packages/pie-menu/src/usePieMenu.ts
+++ b/packages/pie-menu/src/usePieMenu.ts
@@ -7,7 +7,7 @@ const DEFAULT_MOVE_TOLERANCE = 8;
 export function usePieMenu(options: UsePieMenuOptions = {}): UsePieMenuReturn {
   const {
     longPressMs = DEFAULT_LONG_PRESS_MS,
-    movementToleranceX = DEFAULT_MOVE_TOLERANCE,
+    movementTolerance = DEFAULT_MOVE_TOLERANCE,
     enableContextMenu = true,
     enableLongPress = true,
     haptic = true,
@@ -74,11 +74,11 @@ export function usePieMenu(options: UsePieMenuOptions = {}): UsePieMenuReturn {
       if (start.id !== e.pointerId) return;
       const dx = Math.abs(e.clientX - start.x);
       const dy = Math.abs(e.clientY - start.y);
-      if (dx > movementToleranceX || dy > movementToleranceX) {
+      if (dx > movementTolerance || dy > movementTolerance) {
         clearTimer();
       }
     },
-    [clearTimer, movementToleranceX],
+    [clearTimer, movementTolerance],
   );
 
   const onPointerUp = useCallback(

--- a/packages/pie-menu/tsconfig.build.json
+++ b/packages/pie-menu/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "allowImportingTsExtensions": false
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/pie-menu/tsconfig.json
+++ b/packages/pie-menu/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "useDefineForClassFields": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src"]
+}

--- a/packages/pie-menu/vite.config.ts
+++ b/packages/pie-menu/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      formats: ['es'],
+      fileName: () => 'index.js',
+      cssFileName: 'style',
+    },
+    rollupOptions: {
+      external: ['react', 'react-dom', 'react/jsx-runtime'],
+    },
+    sourcemap: true,
+    cssCodeSplit: false,
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents working on this codebase.

## What's included

- Overview of the project (Tauri v2 desktop app with React 19 + Rust)
- Tooling requirements (Node 24, Rust stable, npm)
- Key commands table (lint, build, run)
- Important note: app runs via `npm run tauri dev`, not in a browser
- Editor behavior notes (e.g. list auto-population)
- Linux system dependency list for Tauri/WebKit
- VM-specific gotchas (DRI3 warning, PATH ordering for Node 24)

## Demo

<a href="https://cursor.com/agents/bc-2892be2d-6ff7-4e28-a0c0-004c80a6ba6f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnoteban_create_note_with_title.mp4"><img src="https://cursor.com/artifacts/c/art-e49f5803-178e-46e0-83ed-f6dbceffd9de" alt="noteban_create_note_with_title.mp4" /></a>

Creating a note with a markdown heading title in the Tauri desktop app.

![Note with title and list](https://cursor.com/artifacts/c/art-8b7bb0e0-2bab-4612-a8de-9bc44ed19752)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2892be2d-6ff7-4e28-a0c0-004c80a6ba6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2892be2d-6ff7-4e28-a0c0-004c80a6ba6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

