### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,4 +53,4 @@ When recording demo videos of Noteban:
 ### Gotchas
 
 - In headless/VM environments, you may see `libEGL warning: DRI3 error` — this is harmless (no GPU acceleration).
-- The `PATH` must have Node 24 before `/exec-daemon/node` (which ships Node 22). Use: `export PATH="/home/ubuntu/.nvm/versions/node/v24.16.0/bin:$PATH"`.
+- The `PATH` must have Node 24 before `/exec-daemon/node` (which ships Node 22). Use: `export PATH="$(ls -d /home/ubuntu/.nvm/versions/node/v24.*/bin | tail -1):$PATH"`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Noteban is a Tauri v2 desktop app (React 19 + Rust) for markdown note-taking with Kanban organization.
+
+### Tooling
+
+- **Node.js 24** and **Rust stable** are required (see `mise.toml`).
+- The lockfile is `package-lock.json` — use `npm` (not pnpm/yarn).
+
+### Running the app
+
+Run via Tauri, not the browser — this is a native desktop app:
+
+```sh
+export DISPLAY=:1
+npm run tauri dev
+```
+
+This starts both the Vite dev server (frontend HMR) and the Rust backend with a WebKit webview. The app is never intended to run standalone in a browser.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm install` |
+| Lint | `npm run lint` |
+| TypeScript check | `npx tsc -b` |
+| Build frontend | `npm run build` |
+| Build Rust backend | `cd src-tauri && cargo build` |
+| Run app (dev) | `npm run tauri dev` |
+
+### Linux system dependencies (Tauri/WebKit)
+
+Required packages on Ubuntu/Debian: `libwebkit2gtk-4.1-dev`, `libgtk-3-dev`, `libsoup-3.0-dev`, `libjavascriptcoregtk-4.1-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`, `libxdo-dev`, `libssl-dev`.
+
+### Editor behavior notes
+
+- Notes are stored as markdown files with YAML frontmatter in a user-selected directory.
+- SQLite is bundled in the Rust binary (no external DB needed).
+- Ollama (AI tag suggestions) is optional and not required for core functionality.
+
+### Demo recording guidelines
+
+When recording demo videos of Noteban:
+
+- **Notes must start with a title.** Always type a markdown heading (e.g. `# My Note Title`) as the first line of any new note.
+- **Lists auto-continue.** After typing `- ` on the first list item and pressing Enter, the editor pre-populates subsequent lines with `- `. Do NOT manually type the dash prefix on follow-up list items — just type the text content directly.
+
+### Gotchas
+
+- In headless/VM environments, you may see `libEGL warning: DRI3 error` — this is harmless (no GPU acceleration).
+- The `PATH` must have Node 24 before `/exec-daemon/node` (which ships Node 22). Use: `export PATH="/home/ubuntu/.nvm/versions/node/v24.16.0/bin:$PATH"`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

Based directly on `main` (no dependency on other PRs).

## What's included

- Overview of the project (Tauri v2 desktop app with React 19 + Rust)
- Tooling requirements (Node 24, Rust stable, npm)
- Key commands table (lint, build, run)
- Important note: app runs via `npm run tauri dev`, not in a browser
- Demo recording guidelines: notes start with a title, lists auto-continue after the first `- `
- Linux system dependency list for Tauri/WebKit
- VM-specific gotchas (DRI3 warning, PATH ordering for Node 24)

## Demo

<a href="https://cursor.com/agents/bc-2892be2d-6ff7-4e28-a0c0-004c80a6ba6f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnoteban_create_note_with_title.mp4"><img src="https://cursor.com/artifacts/c/art-22a4a1f1-0132-47e5-b117-c06f8bd703be" alt="noteban_create_note_with_title.mp4" /></a>

![Note with title and features list](https://cursor.com/artifacts/c/art-8b7bb0e0-2bab-4612-a8de-9bc44ed19752)

> Note: Please close PR #105 which was incorrectly based on another PR branch.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2892be2d-6ff7-4e28-a0c0-004c80a6ba6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2892be2d-6ff7-4e28-a0c0-004c80a6ba6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

