### PR TITLE
Combined automated PRs (2026-05-29)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
-        "typescript": "~5.9.3",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.46.4",
         "vite": "^8.0.8"
       }
@@ -3731,9 +3731,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4018,7 +4018,7 @@
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
-        "typescript": "~5.9.3",
+        "typescript": "~6.0.3",
         "vite": "^8.0.8"
       },
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "gray-matter": "^4.0.3",
         "lucide-react": "^1.17.0",
         "react": "^19.2.6",
-        "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.6",
         "uuid": "^14.0.0",
         "zustand": "^5.0.13"
@@ -714,12 +713,6 @@
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
       }
-    },
-    "node_modules/@date-fns/tz": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
-      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
-      "license": "MIT"
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
@@ -1531,15 +1524,6 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tabby_ai/hijri-converter": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
-      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
     },
     "node_modules/@tauri-apps/api": {
       "version": "2.11.0",
@@ -2415,12 +2399,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
-    },
-    "node_modules/date-fns-jalali": {
-      "version": "4.1.0-0",
-      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
-      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3540,28 +3518,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-day-picker": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
-      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@date-fns/tz": "^1.4.1",
-        "@tabby_ai/hijri-converter": "1.0.5",
-        "date-fns": "^4.1.0",
-        "date-fns-jalali": "4.1.0-0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/gpbl"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@tauri-apps/cli": "^2.11.2",
-        "@types/node": "^24.10.1",
+        "@types/node": "^25.9.1",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -1846,13 +1846,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/react": {
@@ -3762,9 +3762,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "date-fns": "^4.0.0",
         "fuse.js": "^7.3.0",
         "gray-matter": "^4.0.3",
-        "lucide-react": "^0.400.0",
+        "lucide-react": "^1.17.0",
         "react": "^19.2.6",
         "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.6",
@@ -3308,9 +3308,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.400.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.400.0.tgz",
-      "integrity": "sha512-rpp7pFHh3Xd93KHixNgB0SqThMHpYNzsGUu69UaQbSZ75Q/J3m5t6EhKyMT3m4w2WOxmJ2mY0tD3vebnXqQryQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
+      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.46.4",
     "vite": "^8.0.8"
   }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "gray-matter": "^4.0.3",
     "lucide-react": "^1.17.0",
     "react": "^19.2.6",
-    "react-day-picker": "^9.14.0",
     "react-dom": "^19.2.6",
     "uuid": "^14.0.0",
     "zustand": "^5.0.13"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "date-fns": "^4.0.0",
     "fuse.js": "^7.3.0",
     "gray-matter": "^4.0.3",
-    "lucide-react": "^0.400.0",
+    "lucide-react": "^1.17.0",
     "react": "^19.2.6",
     "react-day-picker": "^9.14.0",
     "react-dom": "^19.2.6",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@tauri-apps/cli": "^2.11.2",
-    "@types/node": "^24.10.1",
+    "@types/node": "^25.9.1",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/packages/pie-menu/package.json
+++ b/packages/pie-menu/package.json
@@ -30,7 +30,7 @@
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "vite": "^8.0.8"
   },
   "sideEffects": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2458,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "a76001fb4daed01e5f2b518aac0b4dc592e7c734da63dbffcf0c64fa612a8d0c"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3770,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
 dependencies = [
  "bitflags 2.11.1",
  "fallible-iterator",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ uuid = { version = "1.23", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 tauri-plugin-clipboard-manager = "2.3.2"
 walkdir = "2.5"
-rusqlite = { version = "0.39", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 directories = "6.0"
 sha2 = "0.11"
 regex = "1.12"

--- a/src/components/layout/AboutModal.tsx
+++ b/src/components/layout/AboutModal.tsx
@@ -1,11 +1,26 @@
 import { useEffect, useRef, useState } from 'react';
-import { X, Code, ExternalLink } from 'lucide-react';
+import { X, ExternalLink } from 'lucide-react';
 import { getVersion } from '@tauri-apps/api/app';
 import { useUIStore } from '../../stores';
 import { useUpdater } from '../../hooks';
 import { openExternalUrl } from '../../utils/externalOpen';
 import appIcon from '../../../src-tauri/icons/128x128.png';
 import './AboutModal.css';
+
+// Official GitHub mark from Octicons (primer/octicons, MIT licensed)
+function GitHubIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M6.766 11.328c-2.063-.25-3.516-1.734-3.516-3.656 0-.781.281-1.625.75-2.188-.203-.515-.172-1.609.063-2.062.625-.078 1.468.25 1.968.703.594-.187 1.219-.281 1.985-.281.765 0 1.39.094 1.953.265.484-.437 1.344-.765 1.969-.687.218.422.25 1.515.046 2.047.5.593.766 1.39.766 2.203 0 1.922-1.453 3.375-3.547 3.64.531.344.89 1.094.89 1.954v1.625c0 .468.391.734.86.547C13.781 14.359 16 11.53 16 8.03 16 3.61 12.406 0 7.984 0 3.563 0 0 3.61 0 8.031a7.88 7.88 0 0 0 5.172 7.422c.422.156.828-.125.828-.547v-1.25c-.219.094-.5.156-.75.156-1.031 0-1.64-.562-2.078-1.609-.172-.422-.36-.672-.719-.719-.187-.015-.25-.093-.25-.187 0-.188.313-.328.625-.328.453 0 .844.281 1.25.86.313.452.64.655 1.031.655s.641-.14 1-.5c.266-.265.47-.5.657-.656" />
+    </svg>
+  );
+}
 
 const APP_NAME = 'Noteban';
 const GITHUB_URL = 'https://github.com/noteban/noteban';
@@ -95,7 +110,7 @@ export function AboutModal() {
 
           <div className="about-links">
             <button className="about-link-btn" onClick={handleOpenGitHub}>
-              <Code size={16} />
+              <GitHubIcon size={16} />
               <span>View on GitHub</span>
               <ExternalLink size={12} />
             </button>

--- a/src/components/layout/AboutModal.tsx
+++ b/src/components/layout/AboutModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { X, Github, ExternalLink } from 'lucide-react';
+import { X, Code, ExternalLink } from 'lucide-react';
 import { getVersion } from '@tauri-apps/api/app';
 import { useUIStore } from '../../stores';
 import { useUpdater } from '../../hooks';
@@ -95,7 +95,7 @@ export function AboutModal() {
 
           <div className="about-links">
             <button className="about-link-btn" onClick={handleOpenGitHub}>
-              <Github size={16} />
+              <Code size={16} />
               <span>View on GitHub</span>
               <ExternalLink size={12} />
             </button>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,9 +11,8 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "baseUrl": ".",
     "paths": {
-      "@noteban/pie-menu": ["packages/pie-menu/src/index.ts"]
+      "@noteban/pie-menu": ["./packages/pie-menu/src/index.ts"]
     },
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",


### PR DESCRIPTION
Combines the open Dependabot PRs into a single review, verified together.

> Note: this repo uses Graphite, but the local `gt` auth token was expired, so this branch/PR was created with plain `git` + `gh`. It is **not** registered in the Graphite stack — re-run `gt track` after re-authing if you want it stacked.

## Included
- #107 — bump rusqlite from 0.39.0 to 0.40.0 (`/src-tauri`)
- #108 — bump @types/node from 24.12.4 to 25.9.1
- #110 — bump lucide-react from 0.400.0 to 1.17.0
- #111 — bump typescript from 5.9.3 to 6.0.3

## Removed instead of upgraded
- #109 — `react-day-picker` 9 → 10: the dependency is **unused** (no imports anywhere in `src/`, no dependents). Removed it via `npm uninstall react-day-picker` instead of upgrading. **#109 is superseded** and can be closed.

## Fixes applied for breaking changes
Two breaking changes from the major bumps were patched (commit `Fix TS6 baseUrl deprecation and lucide v1 Github icon removal`):
- **TypeScript 6** (#111): `baseUrl` became a deprecation error (TS5101). Removed `baseUrl` from `tsconfig.app.json` and made the `@noteban/pie-menu` path mapping relative (`./packages/...`) so it resolves without it.
- **lucide-react 1** (#110): the `Github` brand icon was removed. Replaced the `AboutModal` "View on GitHub" button icon with the official GitHub mark (inline SVG from [Octicons](https://github.com/primer/octicons), MIT licensed).

## Verification
Ran on the merged branch:
- `npm ci` ✅
- `npm run build` (`tsc -b && vite build`) ✅
- `cargo build` ✅ / `cargo test` ✅ (11 passed) — required Rust stable 1.96 (matches CI; local was pinned to a stale 1.92 where `libsqlite3-sys` 0.38 fails to compile)
- `npm run lint` ⚠️ — fails with **1 pre-existing error** (`SettingsModal.tsx`: `react-hooks/set-state-in-effect`). Confirmed identical failure on `main`; not introduced by these bumps.

<details>
<summary>cargo test output</summary>

```
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

</details>

Once merged, #107, #108, #109, #110, #111 can all be closed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major TypeScript and lucide upgrades plus rusqlite/SQLite native stack changes can surface compile or runtime issues; scope is mostly tooling and one UI icon with no auth or data-model logic changes in the diff.
> 
> **Overview**
> This PR **bundles several dependency updates** and small follow-up fixes for breaking changes.
> 
> **Rust:** `rusqlite` is bumped to **0.40** in `src-tauri` (lockfile pulls `libsqlite3-sys` 0.38).
> 
> **JavaScript:** **TypeScript ~6**, **`@types/node` 25**, and **`lucide-react` 1.x** are upgraded in the root app and `packages/pie-menu`. The unused **`react-day-picker`** dependency is **removed** from `package.json` / lockfile rather than upgraded.
> 
> **TypeScript 6:** `baseUrl` is dropped from `tsconfig.app.json` (avoids TS5101), and the `@noteban/pie-menu` path alias is made explicitly relative (`./packages/...`).
> 
> **lucide-react 1:** The removed **`Github`** icon is replaced in **About** with a local **Octicons-style `GitHubIcon` SVG** on the “View on GitHub” button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26745feb1c845429c94c62e38f9c35d35cacc31f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->