### PR TITLE
Combined automated PRs (2026-06-16)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@tauri-apps/plugin-updater": "^2.10.1",
         "@uiw/react-codemirror": "^4.25.9",
         "date-fns": "^4.0.0",
-        "fuse.js": "^7.3.0",
+        "fuse.js": "^7.4.1",
         "gray-matter": "^4.0.3",
         "lucide-react": "^1.17.0",
         "react": "^19.2.6",
@@ -2778,9 +2778,9 @@
       }
     },
     "node_modules/fuse.js": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
-      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.4.1.tgz",
+      "integrity": "sha512-AY7lKAXK71hi3WgUvDy6oZL67UEHOOtvCAwVdOXHyJd6ZzftBy7QqxuXt4HxmmAhYjmp/YCuOELZtIvAdlZ+fw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "fuse.js": "^7.3.0",
         "gray-matter": "^4.0.3",
         "lucide-react": "^1.17.0",
-        "react": "^19.2.6",
+        "react": "^19.2.7",
         "react-dom": "^19.2.6",
         "uuid": "^14.0.0",
         "zustand": "^5.0.13"
@@ -40,7 +40,7 @@
         "@eslint/js": "^10.0.1",
         "@tauri-apps/cli": "^2.11.2",
         "@types/node": "^25.9.1",
-        "@types/react": "^19.2.15",
+        "@types/react": "^19.2.16",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^10.4.0",
@@ -1859,9 +1859,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.15",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
-      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "version": "19.2.16",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
+      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -3512,9 +3512,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3983,7 +3983,7 @@
       "name": "@noteban/pie-menu",
       "version": "0.1.0",
       "devDependencies": {
-        "@types/react": "^19.2.5",
+        "@types/react": "^19.2.16",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "typescript": "~6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
         "@uiw/react-codemirror": "^4.25.9",
-        "date-fns": "^4.0.0",
+        "date-fns": "^4.4.0",
         "fuse.js": "^7.3.0",
         "gray-matter": "^4.0.3",
         "lucide-react": "^1.17.0",
@@ -2391,9 +2391,9 @@
       "license": "MIT"
     },
     "node_modules/date-fns": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.3.0.tgz",
-      "integrity": "sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "gray-matter": "^4.0.3",
         "lucide-react": "^1.17.0",
         "react": "^19.2.6",
-        "react-dom": "^19.2.6",
+        "react-dom": "^19.2.7",
         "uuid": "^14.0.0",
         "zustand": "^5.0.13"
       },
@@ -3512,24 +3512,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/rolldown": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "uuid": "^14.0.0",
-        "zustand": "^5.0.13"
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -3951,9 +3951,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
-      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gray-matter": "^4.0.3",
     "lucide-react": "^1.17.0",
     "react": "^19.2.6",
-    "react-dom": "^19.2.6",
+    "react-dom": "^19.2.7",
     "uuid": "^14.0.0",
     "zustand": "^5.0.13"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "@uiw/react-codemirror": "^4.25.9",
-    "date-fns": "^4.0.0",
+    "date-fns": "^4.4.0",
     "fuse.js": "^7.3.0",
     "gray-matter": "^4.0.3",
     "lucide-react": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "fuse.js": "^7.3.0",
     "gray-matter": "^4.0.3",
     "lucide-react": "^1.17.0",
-    "react": "^19.2.6",
+    "react": "^19.2.7",
     "react-dom": "^19.2.6",
     "uuid": "^14.0.0",
     "zustand": "^5.0.13"
@@ -47,7 +47,7 @@
     "@eslint/js": "^10.0.1",
     "@tauri-apps/cli": "^2.11.2",
     "@types/node": "^25.9.1",
-    "@types/react": "^19.2.15",
+    "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tauri-apps/plugin-updater": "^2.10.1",
     "@uiw/react-codemirror": "^4.25.9",
     "date-fns": "^4.0.0",
-    "fuse.js": "^7.3.0",
+    "fuse.js": "^7.4.1",
     "gray-matter": "^4.0.3",
     "lucide-react": "^1.17.0",
     "react": "^19.2.6",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "uuid": "^14.0.0",
-    "zustand": "^5.0.13"
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/packages/pie-menu/package.json
+++ b/packages/pie-menu/package.json
@@ -27,7 +27,7 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
-    "@types/react": "^19.2.5",
+    "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "typescript": "~6.0.3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3754,9 +3754,12 @@ dependencies = [
 
 [[package]]
 name = "roxmltree"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "rsqlite-vfs"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2496,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 dependencies = [
  "value-bag",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -621,9 +621,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1806,14 +1806,17 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2458,9 +2461,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76001fb4daed01e5f2b518aac0b4dc592e7c734da63dbffcf0c64fa612a8d0c"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3770,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags 2.11.1",
  "fallible-iterator",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5514,9 +5514,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,7 +38,7 @@ tauri-plugin-opener = "2"
 atomicwrites = "0.4"
 keyring = { version = "3.6", default-features = false, features = ["apple-native", "windows-native", "sync-secret-service"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-roxmltree = "0.20"
+roxmltree = "0.21"
 url = "2.5"
 urlencoding = "2.1"
 rustls = { version = "0.23.38", default-features = false, features = ["ring"] }


### PR DESCRIPTION
Combines the open automated dependency PRs into a single review. All candidates are dependabot-authored (this repo has no `automated` label), and all 10 were `MERGEABLE` against `main`.

## Included (merged cleanly)
- #125 — bump uuid from 1.23.1 to 1.23.3 in /src-tauri (dependabot)
- #124 — bump chrono from 0.4.44 to 0.4.45 in /src-tauri (dependabot)
- #123 — bump rusqlite from 0.40.0 to 0.40.1 in /src-tauri (dependabot)
- #120 — bump log from 0.4.30 to 0.4.32 in /src-tauri (dependabot)
- #119 — bump roxmltree from 0.20.0 to 0.21.1 in /src-tauri (dependabot)
- #121 — bump react and @types/react (dependabot)
- #118 — bump date-fns from 4.3.0 to 4.4.0 (dependabot)
- #116 — bump zustand from 5.0.13 to 5.0.14 (dependabot)

## Resolved during merge
Both were the standard manifest + lockfile overlap (`package.json` / `package-lock.json`), resolved by taking the union of intended versions and regenerating the lockfile:
- #117 — bump fuse.js from 7.3.0 to 7.4.1 (regenerated `package-lock.json`; kept date-fns at the higher ^4.4.0 from #118; fuse.js resolved to 7.4.2, the highest published match for ^7.4.1)
- #115 — bump react-dom from 19.2.6 to 19.2.7 (regenerated `package-lock.json`; kept react at the higher ^19.2.7 from #121 alongside react-dom ^19.2.7)

## Skipped — needs human judgment
None — all 10 candidates merged.

## Verification
This repo has **no dedicated test suite**; CI's PR gate (`.github/workflows/build.yml`) is a full Tauri build. I ran the local equivalent on the merged branch:

- `npm run build` (`tsc -b && vite build`) — ✅ TypeScript type-check + frontend build pass
- `cargo build` (in `src-tauri`) — ✅ Rust backend compiles with all bumped crates

<details>
<summary>cargo build output (tail)</summary>

```
   Compiling tauri-runtime v2.11.2
   Compiling tauri-runtime-wry v2.11.2
   Compiling tauri-plugin v2.6.2
   Compiling tauri-build v2.6.2
   Compiling tauri-codegen v2.6.2
   Compiling tauri v2.11.2
   Compiling tauri-plugin-fs v2.5.1
   Compiling tauri-plugin-clipboard-manager v2.3.2
   Compiling tauri-plugin-updater v2.10.1
   Compiling tauri-plugin-process v2.3.1
   Compiling tauri-plugin-dialog v2.7.1
   Compiling tauri-plugin-opener v2.5.4
   Compiling tauri-plugin-log v2.8.0
   Compiling noteban v4.0.0 (/Users/thor/Work/personal/noteban/src-tauri)
   Compiling tauri-macros v2.6.2
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 36.74s
```

</details>

Once this is merged, the included PRs above can be closed (they point at this combined PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch/minor dependency-only updates with no app code changes; `roxmltree` 0.21 is a minor bump used for WebDAV XML parsing in sync.
> 
> **Overview**
> Bumps **frontend** dependencies in the root workspace and `packages/pie-menu`: `react` / `react-dom` to **^19.2.7**, `@types/react` to **^19.2.16**, plus patch/minor updates for `date-fns` (^4.4.0), `fuse.js` (^7.4.1, lock resolves to 7.4.2), and `zustand` (^5.0.14), with matching `package-lock.json` changes.
> 
> Bumps **Tauri/Rust** deps via `Cargo.toml` / `Cargo.lock`: explicit `roxmltree` **0.21** (was 0.20); transitive updates include `chrono`, `rusqlite`, `log`, `uuid`, `libsqlite3-sys`, and `hashlink` / `hashbrown` chain from the SQLite stack.
> 
> No application source changes—manifest and lockfiles only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d03298ccd082e925f0bc4597ac67487cdf043a99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->