### PR TITLE
feat: Apple Notes-style inline math with live results

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: verify
+description: Verify noteban editor changes at a real rendered surface without launching the Tauri app — mount CodeMirror plugins in headless Chromium and screenshot.
+---
+
+# Verifying noteban changes
+
+Noteban is a Tauri v2 app; `npm run tauri dev` launches a native window (assume the
+user's dev instance is already running — don't start another). The frontend cannot
+boot standalone in a browser (Tauri `invoke` calls fail before the editor renders).
+
+## Editor-plugin changes (CodeMirror decorations, themes, keymaps)
+
+CM6 plugins can be observed in a plain browser page without Tauri:
+
+1. Create `.verify-harness/main.ts` in the repo (must live inside the repo so
+   `@codemirror/*` resolves from its node_modules). Import the plugin(s) under test
+   plus `EditorView` and mount one editor per scenario; `view.dispatch()` a change
+   to exercise the `update()` path. Assert doc integrity into a `#status` div.
+2. `.verify-harness/index.html`: dark `#1e1e2e` body, mount divs, `<script src="bundle.js">`.
+3. Bundle (absolute paths required — relative entry fails to resolve):
+   `npx rolldown "$PWD/.verify-harness/main.ts" -o "$PWD/.verify-harness/bundle.js" -f iife -p browser`
+4. Screenshot with Playwright's cached headless shell (no install needed):
+   `~/Library/Caches/ms-playwright/chromium_headless_shell-*/chrome-headless-shell-mac-arm64/chrome-headless-shell --headless --disable-gpu --hide-scrollbars --screenshot=$PWD/.verify-harness/shot.png --window-size=860,1600 --virtual-time-budget=3000 "file://$PWD/.verify-harness/index.html"`
+   For text assertions use `--dump-dom` and grep instead.
+5. Read the PNG, then `rm -rf .verify-harness` — never commit it.
+
+## Non-editor changes (stores, Tauri commands, layout)
+
+No headless recipe exists yet; these need the running app. Ask the user to check
+their dev instance, or record what you'd need and extend this skill.
+
+## Gotchas
+
+- `npm test` without the repo's `vitest.config.ts` sweeps up 190 broken test files
+  from the `.trunk` plugin cache — the config's `include: ['src/**/*.test.{ts,tsx}']`
+  is load-bearing.
+- Pre-existing lint failures on main (SettingsModal set-state-in-effect error,
+  MarkdownEditor unused-directive warning) — don't attribute them to your diff;
+  compare with `git stash && npm run lint && git stash pop`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,8 @@
         "globals": "^17.4.0",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.46.4",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1543,6 +1544,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
@@ -1844,6 +1852,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -2218,6 +2244,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2265,6 +2404,16 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/balanced-match": {
@@ -2357,6 +2506,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/codemirror": {
       "version": "6.0.2",
@@ -2459,6 +2618,13 @@
       "integrity": "sha512-PUY2DrLvkjkUuWqq+KPL2iWshrJsZOcIojzRQ7eXFacc9dWga7MGMJAa15VbiejSZB1PAXaRLAiKgruHP8LB1w==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2668,6 +2834,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2676,6 +2852,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend-shallow": {
@@ -3331,6 +3517,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -3388,6 +3584,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/optionator": {
@@ -3459,6 +3669,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3636,6 +3853,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3652,6 +3876,20 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/strip-bom-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
@@ -3666,6 +3904,23 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -3682,6 +3937,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3893,6 +4158,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -3913,6 +4268,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest run",
     "preview": "vite preview",
     "tauri": "tauri",
     "ios:init": "tauri ios init",
@@ -56,6 +57,7 @@
     "globals": "^17.4.0",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.9"
   }
 }

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -12,6 +12,7 @@ import { useNotesStore, useSettingsStore, useUIStore } from '../../stores';
 import { useDebounce } from '../../hooks/useDebounce';
 import { checkboxPlugin, checkboxTheme } from './checkboxPlugin';
 import { tagPlugin, tagTheme } from './tagPlugin';
+import { mathPlugin, mathTheme } from './mathPlugin';
 import { tagAutocomplete } from './tagAutocompletePlugin';
 import { linkPlugin, linkTheme, modifierClassPlugin, linkClickHandler } from './linkPlugin';
 import { imagePlugin } from './imagePlugin';
@@ -214,6 +215,8 @@ export function MarkdownEditor({ className }: MarkdownEditorProps) {
       checkboxTheme,
       tagPlugin,
       tagTheme,
+      mathPlugin,
+      mathTheme,
       tagAutocomplete(tagsByFrequency),
       linkPlugin,
       modifierClassPlugin,

--- a/src/components/editor/mathPlugin.ts
+++ b/src/components/editor/mathPlugin.ts
@@ -1,0 +1,128 @@
+import {
+  ViewPlugin,
+  Decoration,
+  WidgetType,
+  EditorView,
+} from '@codemirror/view';
+import type { DecorationSet, ViewUpdate } from '@codemirror/view';
+import type { Range } from '@codemirror/state';
+import { analyzeDocument } from '../../utils/mathEvaluator';
+
+// Ghost result rendered after a trailing '='. Read-only: the computed value
+// lives only in this decoration and is never written into the document.
+class MathResultWidget extends WidgetType {
+  readonly text: string;
+
+  constructor(text: string) {
+    super();
+    this.text = text;
+  }
+
+  toDOM(): HTMLElement {
+    const span = document.createElement('span');
+    span.className = 'cm-math-result';
+    span.textContent = this.text;
+    span.setAttribute('aria-hidden', 'true');
+    return span;
+  }
+
+  eq(other: MathResultWidget): boolean {
+    return other.text === this.text;
+  }
+
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+// The whole document is analyzed (not just the viewport) because definitions
+// above the viewport must stay in scope — same full-scan trade-off the tag
+// and link plugins already make. Notes are small; if a pathological note ever
+// matters, cache parses per line text.
+function mathDecorations(view: EditorView): DecorationSet {
+  const doc = view.state.doc;
+  const lines: string[] = [];
+  for (let i = 1; i <= doc.lines; i++) {
+    lines.push(doc.line(i).text);
+  }
+
+  const decorations: Range<Decoration>[] = [];
+  const results = analyzeDocument(lines);
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (!result) continue;
+    const line = doc.line(i + 1);
+    if (result.nameSpan) {
+      decorations.push(
+        Decoration.mark({ class: 'cm-math-name' }).range(
+          line.from + result.nameSpan.from,
+          line.from + result.nameSpan.to
+        )
+      );
+    }
+    for (const span of result.refSpans) {
+      decorations.push(
+        Decoration.mark({ class: 'cm-math-ref' }).range(
+          line.from + span.from,
+          line.from + span.to
+        )
+      );
+    }
+    if (result.resultText !== undefined && result.resultOffset !== undefined) {
+      decorations.push(
+        Decoration.widget({
+          widget: new MathResultWidget(result.resultText),
+          side: 1,
+        }).range(line.from + result.resultOffset)
+      );
+    }
+  }
+
+  return Decoration.set(decorations, true);
+}
+
+export const mathPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = mathDecorations(view);
+    }
+
+    update(update: ViewUpdate) {
+      // Decorations cover the whole document, so viewport changes (scrolling)
+      // don't require a rebuild. Strictly derive-and-render: no dispatches,
+      // no event handlers, so undo history is never touched.
+      if (update.docChanged) {
+        this.decorations = mathDecorations(update.view);
+      }
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  }
+);
+
+export const mathTheme = EditorView.baseTheme({
+  '.cm-math-name': {
+    color: 'var(--ctp-mauve, #cba6f7)',
+    fontWeight: '600',
+  },
+  '.cm-math-ref': {
+    color: 'var(--ctp-mauve, #cba6f7)',
+  },
+  // The markdown syntax highlighter nests its own token spans (with a plain
+  // text color) inside these marks; the inner span's color would win, leaving
+  // variables white. Force nested spans to take the mark's color instead.
+  '.cm-math-name span, .cm-math-ref span': {
+    color: 'inherit',
+  },
+  '.cm-math-result': {
+    color: 'var(--ctp-mauve, #cba6f7)',
+    opacity: '0.75',
+    paddingLeft: '0.4em',
+    whiteSpace: 'nowrap',
+    userSelect: 'none',
+    '-webkit-user-select': 'none',
+  },
+});

--- a/src/utils/mathEvaluator.test.ts
+++ b/src/utils/mathEvaluator.test.ts
@@ -409,6 +409,37 @@ describe('currency', () => {
     const prelude = ['Price = 3200 NOK / 32GB'];
     expect(analyzeLine('Price in NOK/GB =', prelude)?.resultText).toBe('100 NOK/GB');
   });
+
+  it('assigns notation with alias lines like $ = USD', () => {
+    const results = analyzeDocument(['$ = USD', '$100 + 50 USD =', '$100 =']);
+    expect(results[0]?.kind).toBe('definition');
+    expect(results[1]?.resultText).toBe('150 USD');
+    expect(results[2]?.resultText).toBe('100 USD');
+  });
+
+  it('aliases kr and other symbols', () => {
+    expect(analyzeLine('100 SEK + 50 kr =', ['kr = SEK'])?.resultText).toBe('150 SEK');
+    expect(analyzeLine('¥100 + 100 CNY =', ['¥ = CNY'])?.resultText).toBe('200 CNY');
+    expect(analyzeLine('100 kr in SEK =', ['kr = SEK'])?.resultText).toBe('100 SEK');
+  });
+
+  it('scopes aliases top-to-bottom with override', () => {
+    const results = analyzeDocument([
+      '$1 + 1 USD =',
+      '$ = USD',
+      '$1 + 1 USD =',
+      '$ = CAD',
+      '$1 + 1 CAD =',
+    ]);
+    expect(results[0]).toBeNull();
+    expect(results[2]?.resultText).toBe('2 USD');
+    expect(results[4]?.resultText).toBe('2 CAD');
+  });
+
+  it('does not treat non-marker assignments as aliases', () => {
+    expect(analyzeLine('Deadline = USD')).toBeNull();
+    expect(analyzeLine('NOK = USD')).toBeNull();
+  });
 });
 
 describe('word multipliers', () => {

--- a/src/utils/mathEvaluator.test.ts
+++ b/src/utils/mathEvaluator.test.ts
@@ -183,6 +183,16 @@ describe('document structure', () => {
     expect(results.every((r) => r === null)).toBe(true);
   });
 
+  it('ignores tilde-fenced code', () => {
+    const results = analyzeDocument(['~~~python', 'x = 5', '~~~', 'x =']);
+    expect(results.every((r) => r === null)).toBe(true);
+  });
+
+  it('does not close a backtick fence with a tilde line', () => {
+    const results = analyzeDocument(['```', '~~~', 'x = 5', '```', 'x =']);
+    expect(results.every((r) => r === null)).toBe(true);
+  });
+
   it('ignores frontmatter', () => {
     const results = analyzeDocument(['---', 'x = 5', '---', 'x =']);
     expect(results.every((r) => r === null)).toBe(true);

--- a/src/utils/mathEvaluator.test.ts
+++ b/src/utils/mathEvaluator.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeDocument, formatResult } from './mathEvaluator';
+import type { MathLineResult } from './mathEvaluator';
+
+/** Analyze `line` with optional preceding lines; return the last line's result. */
+function analyzeLine(line: string, prelude: string[] = []): MathLineResult | null {
+  const results = analyzeDocument([...prelude, line]);
+  return results[results.length - 1];
+}
+
+function valueOf(line: string, prelude: string[] = []): number | undefined {
+  return analyzeLine(line, prelude)?.value;
+}
+
+describe('arithmetic', () => {
+  it('adds', () => {
+    const result = analyzeLine('2 + 2 =');
+    expect(result?.kind).toBe('evaluation');
+    expect(result?.resultText).toBe('4');
+  });
+
+  it('respects parentheses', () => {
+    expect(valueOf('2 + (3 × 4) =')).toBe(14);
+  });
+
+  it('handles ascii and unicode operators', () => {
+    expect(valueOf('2 + 3 * 4 =')).toBe(14);
+    expect(valueOf('10 ÷ 4 =')).toBe(2.5);
+    expect(valueOf('10 / 4 =')).toBe(2.5);
+  });
+
+  it('makes ^ right-associative', () => {
+    expect(valueOf('2 ^ 3 ^ 2 =')).toBe(512);
+  });
+
+  it('binds unary minus looser than ^, exponents may be signed', () => {
+    expect(valueOf('-2 ^ 2 =')).toBe(-4);
+    expect(valueOf('2 ^ -1 =')).toBe(0.5);
+  });
+
+  it('supports scientific style via ^', () => {
+    expect(analyzeLine('32×10^9 =')?.resultText).toBe('32 000 000 000');
+  });
+});
+
+describe('definitions and scoping', () => {
+  it('defines and evaluates a variable', () => {
+    const result = analyzeLine('x =', ['x = -3']);
+    expect(result?.kind).toBe('evaluation');
+    expect(result?.value).toBe(-3);
+  });
+
+  it('works without spaces', () => {
+    expect(analyzeLine('x=-3')?.kind).toBe('definition');
+  });
+
+  it('resolves references and reports their spans', () => {
+    const result = analyzeLine('y = x + 1', ['x = 5']);
+    expect(result?.value).toBe(6);
+    expect(result?.refSpans).toEqual([{ from: 4, to: 5 }]);
+  });
+
+  it('lets the nearest definition above win', () => {
+    expect(valueOf('x =', ['x = 1', 'x = 2'])).toBe(2);
+  });
+
+  it('leaves forward references undefined', () => {
+    const results = analyzeDocument(['y = x + 1', 'x = 5', 'y =']);
+    expect(results[0]).toBeNull();
+    expect(results[2]).toBeNull();
+  });
+
+  it('handles definition-evaluation lines', () => {
+    const result = analyzeLine('Total = 2 × 3 =');
+    expect(result?.kind).toBe('definition-evaluation');
+    expect(result?.resultText).toBe('6');
+    expect(result?.nameSpan).toEqual({ from: 0, to: 5 });
+    expect(valueOf('Total =', ['Total = 2 × 3 ='])).toBe(6);
+  });
+
+  it('evaluates a bare variable reference', () => {
+    expect(valueOf('ModelSize =', ['ModelSize = 5'])).toBe(5);
+  });
+
+  it('is case-sensitive', () => {
+    expect(analyzeLine('x =', ['X = 5'])).toBeNull();
+  });
+});
+
+describe('prose rejection', () => {
+  it('ignores prose-shaped assignments with undefined references', () => {
+    expect(analyzeLine('Deadline = Friday')).toBeNull();
+    expect(analyzeLine('a = b')).toBeNull();
+  });
+
+  it('rejects chained assignments', () => {
+    expect(analyzeLine('a = b = c')).toBeNull();
+  });
+
+  it('accepts the same shape once the reference is defined', () => {
+    expect(analyzeLine('Deadline = Friday', ['Friday = 5'])?.kind).toBe('definition');
+  });
+});
+
+describe('percentages', () => {
+  it('evaluates a bare percent literal', () => {
+    expect(valueOf('20% =')).toBe(0.2);
+  });
+
+  it('applies Apple-style relative percent on + and -', () => {
+    expect(valueOf('100 + 20% =')).toBe(120);
+    expect(valueOf('100 - 20% =')).toBe(80);
+  });
+
+  it('treats percent as a plain scalar elsewhere', () => {
+    expect(valueOf('100 × 20% =')).toBe(20);
+    expect(valueOf('20% + 100 =')).toBe(100.2);
+    expect(valueOf('100 + (20%) =')).toBe(100.2);
+    expect(valueOf('100 + 20% × 2 =')).toBe(100.4);
+  });
+
+  it('chains relative percents left-associatively', () => {
+    expect(valueOf('50 + 50% + 10% =')).toBe(82.5);
+  });
+});
+
+describe('unit suffixes', () => {
+  it('expands k/K/M/G/T', () => {
+    expect(analyzeLine('8k =')?.resultText).toBe('8 000');
+    expect(analyzeLine('8K =')?.resultText).toBe('8 000');
+    expect(analyzeLine('32G =')?.resultText).toBe('32 000 000 000');
+    expect(analyzeLine('1.5M =')?.resultText).toBe('1 500 000');
+    expect(analyzeLine('2T =')?.resultText).toBe('2 000 000 000 000');
+  });
+
+  it('rejects suffixes glued to identifiers and lowercase m/g/t', () => {
+    expect(analyzeLine('8km =')).toBeNull();
+    expect(analyzeLine('32g =')).toBeNull();
+    expect(analyzeLine('8m =')).toBeNull();
+  });
+});
+
+describe('functions', () => {
+  it('evaluates builtins', () => {
+    expect(valueOf('min(3, 5) =')).toBe(3);
+    expect(valueOf('max(1,2,3) =')).toBe(3);
+    expect(valueOf('sqrt(9) =')).toBe(3);
+    expect(valueOf('round(2.5) =')).toBe(3);
+    expect(valueOf('log2(8) =')).toBe(3);
+    expect(valueOf('floor(1.9) =')).toBe(1);
+    expect(valueOf('ceil(1.1) =')).toBe(2);
+    expect(valueOf('abs(-2) =')).toBe(2);
+  });
+
+  it('rejects unknown functions and wrong arity', () => {
+    expect(analyzeLine('nope(3) =')).toBeNull();
+    expect(analyzeLine('sqrt() =')).toBeNull();
+  });
+
+  it('allows function names as variables outside call position', () => {
+    expect(analyzeLine('min = 5')?.kind).toBe('definition');
+  });
+});
+
+describe('silent errors', () => {
+  it('hides non-finite results', () => {
+    expect(analyzeLine('1 ÷ 0 =')).toBeNull();
+    expect(analyzeLine('0 ÷ 0 =')).toBeNull();
+    expect(analyzeLine('sqrt(-1) =')).toBeNull();
+  });
+});
+
+describe('document structure', () => {
+  it('ignores headings', () => {
+    expect(analyzeLine('# Heading')).toBeNull();
+    expect(analyzeLine('## H2 =')).toBeNull();
+  });
+
+  it('ignores fenced code and keeps its definitions out of scope', () => {
+    const results = analyzeDocument(['```', 'x = 5', '```', 'x =']);
+    expect(results.every((r) => r === null)).toBe(true);
+  });
+
+  it('ignores frontmatter', () => {
+    const results = analyzeDocument(['---', 'x = 5', '---', 'x =']);
+    expect(results.every((r) => r === null)).toBe(true);
+  });
+
+  it('ignores lines containing backticks', () => {
+    expect(analyzeLine('`x` = 5')).toBeNull();
+  });
+
+  it('ignores checkbox tasks', () => {
+    expect(analyzeLine('- [ ] task = done')).toBeNull();
+  });
+
+  it('does math in list items with offset spans', () => {
+    const result = analyzeLine('- Total = 2 × 3 =');
+    expect(result?.kind).toBe('definition-evaluation');
+    expect(result?.nameSpan).toEqual({ from: 2, to: 7 });
+    expect(result?.value).toBe(6);
+  });
+
+  it('strips comments', () => {
+    expect(valueOf('x =', ['x = 5 # AWQ 4-bit'])).toBe(5);
+  });
+
+  it('places the result before a trailing comment', () => {
+    const result = analyzeLine('2 + 2 = # check');
+    expect(result?.resultText).toBe('4');
+    expect(result?.resultOffset).toBe(7);
+  });
+
+  it('ignores setext underlines, lone =, empty lines, and bare expressions', () => {
+    expect(analyzeLine('===')).toBeNull();
+    expect(analyzeLine('=')).toBeNull();
+    expect(analyzeLine('')).toBeNull();
+    expect(analyzeLine('2 + 2')).toBeNull();
+  });
+});
+
+describe('formatResult', () => {
+  it('groups thousands with spaces', () => {
+    expect(formatResult(62914560000)).toBe('62 914 560 000');
+    expect(formatResult(1234.5678)).toBe('1 234.5678');
+  });
+
+  it('removes float noise', () => {
+    expect(formatResult(0.1 + 0.2)).toBe('0.3');
+  });
+
+  it('normalizes negative zero', () => {
+    expect(formatResult(-0)).toBe('0');
+  });
+
+  it('handles large grouped values', () => {
+    expect(formatResult(19.2e9)).toBe('19 200 000 000');
+  });
+});
+
+describe('screenshot scenario', () => {
+  it('reproduces the LLM-sizing note', () => {
+    const results = analyzeDocument([
+      'Params = 32×10^9',
+      'Quantization = 0.5 # AWQ 4-bit',
+      'ModelSize = Params × Quantization',
+      'ModelSize =',
+      '',
+      'ContextSize = 8×10^3',
+      'Users = 30',
+      '',
+      'Layers = 64',
+      'kvHeads = 8',
+      'headDim = 128',
+      'Bytes = 2',
+      'KV = 2 × Layers × kvHeads × headDim × Bytes',
+      '',
+      'perUser = ContextSize×KV',
+      'perUser =',
+      '',
+      'KVTotal = Users × perUser',
+      'KVTotal =',
+      '',
+      'TotalReq = KVTotal + ModelSize',
+      'TotalReq =',
+    ]);
+    expect(results[3]?.resultText).toBe('16 000 000 000');
+    expect(results[15]?.resultText).toBe('2 097 152 000');
+    expect(results[18]?.resultText).toBe('62 914 560 000');
+    expect(results[21]?.resultText).toBe('78 914 560 000');
+  });
+});

--- a/src/utils/mathEvaluator.test.ts
+++ b/src/utils/mathEvaluator.test.ts
@@ -133,10 +133,12 @@ describe('unit suffixes', () => {
     expect(analyzeLine('2T =')?.resultText).toBe('2 000 000 000 000');
   });
 
-  it('rejects suffixes glued to identifiers and lowercase m/g/t', () => {
-    expect(analyzeLine('8km =')).toBeNull();
-    expect(analyzeLine('32g =')).toBeNull();
-    expect(analyzeLine('8m =')).toBeNull();
+  it('treats glued known-unit idents as quantities, rejects unknown ones', () => {
+    expect(analyzeLine('8km =')?.resultText).toBe('8 km');
+    expect(analyzeLine('32g =')?.resultText).toBe('32 g');
+    expect(analyzeLine('8m =')?.resultText).toBe('8 m');
+    expect(analyzeLine('8foo =')).toBeNull();
+    expect(analyzeLine('8qB =')).toBeNull();
   });
 });
 
@@ -235,6 +237,125 @@ describe('formatResult', () => {
 
   it('handles large grouped values', () => {
     expect(formatResult(19.2e9)).toBe('19 200 000 000');
+  });
+});
+
+describe('extended functions and constants', () => {
+  it('evaluates ln/exp/pow', () => {
+    expect(analyzeLine('ln(e) =')?.resultText).toBe('1');
+    expect(valueOf('exp(1) =')).toBeCloseTo(Math.E, 10);
+    expect(analyzeLine('pow(2, 10) =')?.resultText).toBe('1 024');
+  });
+
+  it('does trig in degrees', () => {
+    expect(analyzeLine('sin(30) =')?.resultText).toBe('0.5');
+    expect(analyzeLine('cos(60) =')?.resultText).toBe('0.5');
+    expect(analyzeLine('tan(45) =')?.resultText).toBe('1');
+    expect(analyzeLine('asin(1) =')?.resultText).toBe('90');
+    expect(analyzeLine('atan(1) =')?.resultText).toBe('45');
+  });
+
+  it('provides pi and e, shadowable by definitions', () => {
+    expect(analyzeLine('pi =')?.resultText).toBe('3.14159265359');
+    expect(valueOf('pi =', ['pi = 3'])).toBe(3);
+    expect(valueOf('e + 1 =')).toBeCloseTo(Math.E + 1, 10);
+  });
+});
+
+describe('thousands-separated input', () => {
+  it('merges space-grouped digits', () => {
+    expect(analyzeLine('16 000 000 000 =')?.resultText).toBe('16 000 000 000');
+    expect(valueOf('1 234.5678 =')).toBe(1234.5678);
+    expect(valueOf('1 000k =')).toBe(1_000_000);
+  });
+
+  it('only merges groups of exactly three digits', () => {
+    expect(analyzeLine('1 23 =')).toBeNull();
+    expect(analyzeLine('1 0000 =')).toBeNull();
+  });
+
+  it('does not interfere with function arguments', () => {
+    expect(valueOf('min(1 000, 2) =')).toBe(2);
+  });
+});
+
+describe('hex and binary', () => {
+  it('parses literals', () => {
+    expect(analyzeLine('0xFF =')?.resultText).toBe('255');
+    expect(valueOf('0xff + 1 =')).toBe(256);
+    expect(analyzeLine('0b1010 =')?.resultText).toBe('10');
+  });
+
+  it('converts output with in hex / in bin', () => {
+    expect(analyzeLine('255 in hex =')?.resultText).toBe('0xFF');
+    expect(analyzeLine('256 in hex =')?.resultText).toBe('0x100');
+    expect(analyzeLine('10 in bin =')?.resultText).toBe('0b1010');
+    expect(analyzeLine('-255 in hex =')?.resultText).toBe('-0xFF');
+  });
+
+  it('rejects malformed literals and non-integer conversions', () => {
+    expect(analyzeLine('0x =')).toBeNull();
+    expect(analyzeLine('0b2 =')).toBeNull();
+    expect(analyzeLine('2.5 in hex =')).toBeNull();
+    expect(analyzeLine('8MB in hex =')).toBeNull();
+  });
+});
+
+describe('units', () => {
+  it('renders auto-scaled results', () => {
+    expect(analyzeLine('8MB =')?.resultText).toBe('8 MB');
+    expect(analyzeLine('6kJ/s =')?.resultText).toBe('6 kW');
+    expect(analyzeLine('8MB + 200kB =')?.resultText).toBe('8.2 MB');
+    expect(analyzeLine('8MB / 2s =')?.resultText).toBe('4 MB/s');
+    expect(analyzeLine('0.25h =')?.resultText).toBe('15 min');
+    expect(analyzeLine('0.5kB =')?.resultText).toBe('500 B');
+    expect(analyzeLine('8bit =')?.resultText).toBe('1 B');
+    expect(analyzeLine('2GHz × 0.5 =')?.resultText).toBe('1 GHz');
+  });
+
+  it('accepts one space between number and unit', () => {
+    expect(analyzeLine('8 MB =')?.resultText).toBe('8 MB');
+    expect(analyzeLine('90 min =')?.resultText).toBe('1.5 h');
+  });
+
+  it('converts with in', () => {
+    expect(analyzeLine('8MB in KiB =')?.resultText).toBe('7 812.5 KiB');
+    expect(analyzeLine('1GiB in MB =')?.resultText).toBe('1 073.741824 MB');
+    expect(analyzeLine('90min in h =')?.resultText).toBe('1.5 h');
+    expect(analyzeLine('Speed in km/h =', ['Speed = 100m / 10s'])?.resultText).toBe('36 km/h');
+  });
+
+  it('handles bits and IEC spelling variants', () => {
+    expect(analyzeLine('8MiB in kiB =')?.resultText).toBe('8 192 kiB');
+    expect(analyzeLine('8Mb in MB =')?.resultText).toBe('1 MB');
+    expect(analyzeLine('8Mb =')?.resultText).toBe('1 MB');
+    expect(analyzeLine('1Gb in Mb =')?.resultText).toBe('1 000 Mb');
+    expect(analyzeLine('8b =')?.resultText).toBe('1 B');
+  });
+
+  it('does dimensional arithmetic through variables', () => {
+    expect(analyzeLine('Speed =', ['Speed = 100m / 10s'])?.resultText).toBe('10 m/s');
+    expect(analyzeLine('X + 2MB =', ['X = 8MB'])?.resultText).toBe('10 MB');
+    expect(analyzeLine('X / 3s =', ['X = 2s × 3s'])?.resultText).toBe('2 s');
+    expect(analyzeLine('2GHz × 3s =')?.resultText).toBe('6 000 000 000');
+  });
+
+  it('applies relative percent to quantities', () => {
+    expect(analyzeLine('8MB + 20% =')?.resultText).toBe('9.6 MB');
+  });
+
+  it('silently rejects mismatched or unrenderable dimensions', () => {
+    expect(analyzeLine('8MB + 2s =')).toBeNull();
+    expect(analyzeLine('8MB + 5 =')).toBeNull();
+    expect(analyzeLine('(2s)^2 =')).toBeNull();
+    expect(analyzeLine('2s × 3s =')).toBeNull();
+    expect(analyzeLine('8MB in s =')).toBeNull();
+    expect(analyzeLine('sqrt(4s) =')).toBeNull();
+  });
+
+  it('keeps bare scale suffixes dimensionless', () => {
+    expect(analyzeLine('8k =')?.resultText).toBe('8 000');
+    expect(analyzeLine('8kB =')?.resultText).toBe('8 kB');
   });
 });
 

--- a/src/utils/mathEvaluator.test.ts
+++ b/src/utils/mathEvaluator.test.ts
@@ -359,6 +359,24 @@ describe('units', () => {
   });
 });
 
+describe('word multipliers', () => {
+  it('folds spelled-out multipliers into the number, case-insensitively', () => {
+    expect(analyzeLine('32 Billion =')?.resultText).toBe('32 000 000 000');
+    expect(analyzeLine('1.5 million =')?.resultText).toBe('1 500 000');
+    expect(analyzeLine('2 Thousand + 1 =')?.resultText).toBe('2 001');
+    expect(valueOf('Params =', ['Params = 32 Billion'])).toBe(32e9);
+  });
+
+  it('composes with units', () => {
+    expect(analyzeLine('3 Million MB =')?.resultText).toBe('3 TB');
+  });
+
+  it('is only a multiplier right after a number', () => {
+    expect(analyzeLine('x = Billion')).toBeNull();
+    expect(analyzeLine('2 Billions =')).toBeNull();
+  });
+});
+
 describe('screenshot scenario', () => {
   it('reproduces the LLM-sizing note', () => {
     const results = analyzeDocument([

--- a/src/utils/mathEvaluator.test.ts
+++ b/src/utils/mathEvaluator.test.ts
@@ -375,6 +375,22 @@ describe('word multipliers', () => {
     expect(analyzeLine('x = Billion')).toBeNull();
     expect(analyzeLine('2 Billions =')).toBeNull();
   });
+
+  it('always reads B as bytes', () => {
+    expect(analyzeLine('32B =')?.resultText).toBe('32 B');
+    expect(analyzeLine('32 B =')?.resultText).toBe('32 B');
+    expect(analyzeLine('4b =')?.resultText).toBe('0.5 B');
+    expect(analyzeLine('500B/s =')?.resultText).toBe('500 B/s');
+  });
+
+  it('handles the LLM-sizing scenario with word multipliers and bits', () => {
+    const result = analyzeLine('ModelSize = Params × BytesPerParam + 20% =', [
+      'Params = 32 Billion',
+      'BytesPerParam = 4b',
+    ]);
+    expect(result?.kind).toBe('definition-evaluation');
+    expect(result?.resultText).toBe('19.2 GB');
+  });
 });
 
 describe('screenshot scenario', () => {

--- a/src/utils/mathEvaluator.test.ts
+++ b/src/utils/mathEvaluator.test.ts
@@ -359,6 +359,58 @@ describe('units', () => {
   });
 });
 
+describe('currency', () => {
+  it('renders money with the marker as typed', () => {
+    expect(analyzeLine('320 USD =')?.resultText).toBe('320 USD');
+    expect(analyzeLine('$320 =')?.resultText).toBe('$320');
+    expect(analyzeLine('€50 + €25 =')?.resultText).toBe('€75');
+    expect(analyzeLine('320kr =')?.resultText).toBe('320 kr');
+    expect(analyzeLine('100 NOK + 50 NOK =')?.resultText).toBe('150 NOK');
+    expect(analyzeLine('320 USD + 25% =')?.resultText).toBe('400 USD');
+    expect(analyzeLine('640 NOK / 320 NOK =')?.resultText).toBe('2');
+  });
+
+  it('accepts any three-uppercase-letter code', () => {
+    expect(analyzeLine('99 ISK =')?.resultText).toBe('99 ISK');
+    expect(analyzeLine('5 Nok =')).toBeNull();
+  });
+
+  it('accepts currency prefixes', () => {
+    expect(analyzeLine('kr 320 =')?.resultText).toBe('320 kr');
+    expect(analyzeLine('kr320 =')).toBeNull(); // lexes as one identifier — prefix needs the space
+    expect(analyzeLine('USD 100 =')?.resultText).toBe('100 USD');
+    expect(analyzeLine('kr 100/h =')?.resultText).toBe('100 kr/h');
+    expect(analyzeLine('kr 320 + kr 80 =')?.resultText).toBe('400 kr');
+  });
+
+  it('computes data per money and money per data', () => {
+    expect(analyzeLine('32GB / 3200 NOK =')?.resultText).toBe('10 MB/NOK');
+    expect(analyzeLine('32GB / 320 USD =')?.resultText).toBe('100 MB/USD');
+    expect(analyzeLine('32GB / $320 =')?.resultText).toBe('100 MB/$');
+    expect(analyzeLine('3200 NOK / 32GB =')?.resultText).toBe('100 NOK/GB');
+  });
+
+  it('handles money rates over time', () => {
+    expect(analyzeLine('$100/h =')?.resultText).toBe('$100/h');
+    expect(analyzeLine('$100/h × 8h =')?.resultText).toBe('$800');
+    expect(analyzeLine('-$5 =')?.resultText).toBe('-$5');
+  });
+
+  it('matches markers strictly — $ is $, kr is kr', () => {
+    expect(analyzeLine('1 USD + 1 NOK =')).toBeNull();
+    expect(analyzeLine('$1 + 1 USD =')).toBeNull();
+    expect(analyzeLine('100 SEK + 50 kr =')).toBeNull();
+    expect(analyzeLine('$50 + €50 =')).toBeNull();
+    expect(analyzeLine('100 USD in NOK =')).toBeNull();
+    expect(analyzeLine('5 NOK/EUR =')).toBeNull();
+  });
+
+  it('converts within the same currency', () => {
+    const prelude = ['Price = 3200 NOK / 32GB'];
+    expect(analyzeLine('Price in NOK/GB =', prelude)?.resultText).toBe('100 NOK/GB');
+  });
+});
+
 describe('word multipliers', () => {
   it('folds spelled-out multipliers into the number, case-insensitively', () => {
     expect(analyzeLine('32 Billion =')?.resultText).toBe('32 000 000 000');

--- a/src/utils/mathEvaluator.ts
+++ b/src/utils/mathEvaluator.ts
@@ -1,0 +1,488 @@
+// Inline math evaluator for Apple Notes-style calculations in notes.
+//
+// A line like `Params = 32×10^9` defines a variable; a line with a trailing
+// `=` (e.g. `ModelSize =` or `2 + (3 × 4) =`) is a request to evaluate the
+// expression before it. Lines that don't fully parse AND evaluate to a finite
+// number are silently ignored (`Deadline = Friday` stays plain prose).
+//
+// Pure module: no CodeMirror, DOM, or Tauri imports. The editor integration
+// lives in src/components/editor/mathPlugin.ts.
+
+export interface MathSpan {
+  /** Column offsets within the line's text. */
+  from: number;
+  to: number;
+}
+
+export type MathLineKind = 'definition' | 'evaluation' | 'definition-evaluation';
+
+export interface MathLineResult {
+  kind: MathLineKind;
+  /** LHS variable name span; present for 'definition' and 'definition-evaluation'. */
+  nameSpan?: MathSpan;
+  /** Spans of variable references in the expression (all resolved, since the line evaluated). */
+  refSpans: MathSpan[];
+  /** Computed value (always finite). */
+  value: number;
+  /** Formatted result text; present for 'evaluation' and 'definition-evaluation'. */
+  resultText?: string;
+  /** Column just after the trailing '='; widget insertion point. */
+  resultOffset?: number;
+}
+
+// --- Tokenizer ---------------------------------------------------------------
+
+type OpChar = '+' | '-' | '*' | '/' | '^' | '%' | '(' | ')' | ',' | '=';
+
+type Token =
+  | { type: 'num'; value: number; from: number; to: number }
+  | { type: 'ident'; name: string; from: number; to: number }
+  | { type: 'op'; op: OpChar; from: number; to: number };
+
+class MathError extends Error {}
+
+// Unicode math operators are normalized to their ASCII equivalents.
+const OP_NORMALIZE: Record<string, OpChar> = {
+  '×': '*',
+  '÷': '/',
+  '−': '-',
+  '+': '+',
+  '-': '-',
+  '*': '*',
+  '/': '/',
+  '^': '^',
+  '%': '%',
+  '(': '(',
+  ')': ')',
+  ',': ',',
+  '=': '=',
+};
+
+// Suffixes are only recognized when not followed by an identifier character
+// (so `8km` and `8k2` fall through to a parse error). Lowercase m/g/t are
+// deliberately rejected: they read as milli/grams/tonnes in prose.
+const SUFFIX_MULTIPLIER: Record<string, number> = {
+  k: 1e3,
+  K: 1e3,
+  M: 1e6,
+  G: 1e9,
+  T: 1e12,
+};
+
+const IDENT_START = /[A-Za-z_]/;
+const IDENT_CHAR = /[A-Za-z0-9_]/;
+const NUMBER_RE = /^(?:\d+(?:\.\d+)?|\.\d+)/;
+
+/**
+ * Tokenize expression text. Token positions are offset by `base` so they map
+ * back to columns in the original (unstripped) line. Returns null on any
+ * unrecognized character.
+ */
+function tokenize(text: string, base: number): Token[] | null {
+  const tokens: Token[] = [];
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === ' ' || ch === '\t') {
+      i++;
+      continue;
+    }
+    const numMatch = NUMBER_RE.exec(text.slice(i));
+    if (numMatch) {
+      let end = i + numMatch[0].length;
+      let value = Number(numMatch[0]);
+      const suffix = text[end];
+      if (
+        suffix !== undefined &&
+        SUFFIX_MULTIPLIER[suffix] !== undefined &&
+        (end + 1 >= text.length || !IDENT_CHAR.test(text[end + 1]))
+      ) {
+        value *= SUFFIX_MULTIPLIER[suffix];
+        end++;
+      }
+      tokens.push({ type: 'num', value, from: base + i, to: base + end });
+      i = end;
+      continue;
+    }
+    if (IDENT_START.test(ch)) {
+      let end = i + 1;
+      while (end < text.length && IDENT_CHAR.test(text[end])) end++;
+      tokens.push({ type: 'ident', name: text.slice(i, end), from: base + i, to: base + end });
+      i = end;
+      continue;
+    }
+    const op = OP_NORMALIZE[ch];
+    if (op !== undefined) {
+      tokens.push({ type: 'op', op, from: base + i, to: base + i + 1 });
+      i++;
+      continue;
+    }
+    return null;
+  }
+  return tokens;
+}
+
+// --- Parser ------------------------------------------------------------------
+
+type AstNode =
+  | { kind: 'num'; value: number }
+  | { kind: 'var'; name: string; span: MathSpan }
+  | { kind: 'call'; name: string; args: AstNode[] }
+  | { kind: 'binary'; op: '+' | '-' | '*' | '/' | '^'; left: AstNode; right: AstNode }
+  | { kind: 'neg'; operand: AstNode }
+  // Percent of a number literal: evaluates to value/100. As the direct right
+  // operand of + or - it triggers Apple-style relative math (X + 20% = X×1.2).
+  | { kind: 'percent'; operand: AstNode }
+  // Parenthesized expression; exists so parens launder percent-ness:
+  // 100 + (20%) is plain addition of 0.2, not a 20% increase.
+  | { kind: 'group'; operand: AstNode };
+
+interface FunctionSpec {
+  minArity: number;
+  maxArity: number;
+  apply: (args: number[]) => number;
+}
+
+const FUNCTIONS: Record<string, FunctionSpec> = {
+  sqrt: { minArity: 1, maxArity: 1, apply: ([x]) => Math.sqrt(x) },
+  abs: { minArity: 1, maxArity: 1, apply: ([x]) => Math.abs(x) },
+  round: { minArity: 1, maxArity: 1, apply: ([x]) => Math.round(x) },
+  floor: { minArity: 1, maxArity: 1, apply: ([x]) => Math.floor(x) },
+  ceil: { minArity: 1, maxArity: 1, apply: ([x]) => Math.ceil(x) },
+  log2: { minArity: 1, maxArity: 1, apply: ([x]) => Math.log2(x) },
+  log10: { minArity: 1, maxArity: 1, apply: ([x]) => Math.log10(x) },
+  min: { minArity: 1, maxArity: Infinity, apply: (args) => Math.min(...args) },
+  max: { minArity: 1, maxArity: Infinity, apply: (args) => Math.max(...args) },
+};
+
+/**
+ * Recursive-descent parser over a token slice. Grammar (precedence low→high):
+ *
+ *   expr           := additive
+ *   additive       := multiplicative (("+"|"-") multiplicative)*   left-assoc
+ *   multiplicative := unary (("*"|"/") unary)*                     left-assoc
+ *   unary          := ("-"|"+") unary | power
+ *   power          := postfix ("^" unary)?                         right-assoc
+ *   postfix        := primary "%"?                                 % after number literals only
+ *   primary        := NUMBER | IDENT | IDENT "(" expr ("," expr)* ")" | "(" expr ")"
+ *
+ * No implicit multiplication: adjacent operands are a parse error.
+ */
+type VarNode = Extract<AstNode, { kind: 'var' }>;
+type IdentToken = Extract<Token, { type: 'ident' }>;
+
+class Parser {
+  private pos = 0;
+  private readonly tokens: readonly Token[];
+  readonly varNodes: VarNode[] = [];
+
+  constructor(tokens: readonly Token[]) {
+    this.tokens = tokens;
+  }
+
+  /** Parse the whole token slice as one expression; throws MathError on failure. */
+  parse(): AstNode {
+    if (this.tokens.length === 0) throw new MathError('empty expression');
+    const node = this.parseAdditive();
+    if (this.pos !== this.tokens.length) throw new MathError('unexpected trailing tokens');
+    return node;
+  }
+
+  private peek(): Token | undefined {
+    return this.tokens[this.pos];
+  }
+
+  private peekOp(): OpChar | undefined {
+    const token = this.peek();
+    return token?.type === 'op' ? token.op : undefined;
+  }
+
+  private expectOp(op: OpChar): void {
+    if (this.peekOp() !== op) throw new MathError(`expected '${op}'`);
+    this.pos++;
+  }
+
+  private parseAdditive(): AstNode {
+    let left = this.parseMultiplicative();
+    for (;;) {
+      const op = this.peekOp();
+      if (op !== '+' && op !== '-') return left;
+      this.pos++;
+      left = { kind: 'binary', op, left, right: this.parseMultiplicative() };
+    }
+  }
+
+  private parseMultiplicative(): AstNode {
+    let left = this.parseUnary();
+    for (;;) {
+      const op = this.peekOp();
+      if (op !== '*' && op !== '/') return left;
+      this.pos++;
+      left = { kind: 'binary', op, left, right: this.parseUnary() };
+    }
+  }
+
+  private parseUnary(): AstNode {
+    const op = this.peekOp();
+    if (op === '-') {
+      this.pos++;
+      return { kind: 'neg', operand: this.parseUnary() };
+    }
+    if (op === '+') {
+      this.pos++;
+      return this.parseUnary();
+    }
+    return this.parsePower();
+  }
+
+  private parsePower(): AstNode {
+    const base = this.parsePostfix();
+    if (this.peekOp() !== '^') return base;
+    this.pos++;
+    // Right-assoc via unary recursion; also allows signed exponents (2^-1).
+    return { kind: 'binary', op: '^', left: base, right: this.parseUnary() };
+  }
+
+  private parsePostfix(): AstNode {
+    const node = this.parsePrimary();
+    if (this.peekOp() === '%') {
+      if (node.kind !== 'num') throw new MathError('% is only supported after a number');
+      this.pos++;
+      return { kind: 'percent', operand: node };
+    }
+    return node;
+  }
+
+  private parsePrimary(): AstNode {
+    const token = this.peek();
+    if (token === undefined) throw new MathError('unexpected end of expression');
+    if (token.type === 'num') {
+      this.pos++;
+      return { kind: 'num', value: token.value };
+    }
+    if (token.type === 'ident') {
+      this.pos++;
+      if (this.peekOp() === '(') {
+        this.pos++;
+        const args: AstNode[] = [this.parseAdditive()];
+        while (this.peekOp() === ',') {
+          this.pos++;
+          args.push(this.parseAdditive());
+        }
+        this.expectOp(')');
+        return { kind: 'call', name: token.name, args };
+      }
+      const node: VarNode = {
+        kind: 'var',
+        name: token.name,
+        span: { from: token.from, to: token.to },
+      };
+      this.varNodes.push(node);
+      return node;
+    }
+    if (token.op === '(') {
+      this.pos++;
+      const operand = this.parseAdditive();
+      this.expectOp(')');
+      return { kind: 'group', operand };
+    }
+    throw new MathError(`unexpected '${token.op}'`);
+  }
+}
+
+// --- Evaluator ---------------------------------------------------------------
+
+function evalNode(node: AstNode, env: ReadonlyMap<string, number>): number {
+  switch (node.kind) {
+    case 'num':
+      return node.value;
+    case 'var': {
+      const value = env.get(node.name);
+      if (value === undefined) throw new MathError(`undefined variable '${node.name}'`);
+      return value;
+    }
+    case 'percent':
+      return evalNode(node.operand, env) / 100;
+    case 'neg':
+      return -evalNode(node.operand, env);
+    case 'group':
+      return evalNode(node.operand, env);
+    case 'call': {
+      const fn = FUNCTIONS[node.name];
+      if (fn === undefined) throw new MathError(`unknown function '${node.name}'`);
+      if (node.args.length < fn.minArity || node.args.length > fn.maxArity) {
+        throw new MathError(`wrong arity for '${node.name}'`);
+      }
+      return fn.apply(node.args.map((arg) => evalNode(arg, env)));
+    }
+    case 'binary': {
+      const left = evalNode(node.left, env);
+      // Apple-style relative percent: X + 20% = X×1.2, X - 20% = X×0.8.
+      // Only when the right operand is literally a percent node — products,
+      // groups, and variables holding percent-derived values stay plain.
+      if ((node.op === '+' || node.op === '-') && node.right.kind === 'percent') {
+        const fraction = evalNode(node.right, env);
+        return node.op === '+' ? left * (1 + fraction) : left * (1 - fraction);
+      }
+      const right = evalNode(node.right, env);
+      switch (node.op) {
+        case '+':
+          return left + right;
+        case '-':
+          return left - right;
+        case '*':
+          return left * right;
+        case '/':
+          return left / right;
+        case '^':
+          return Math.pow(left, right);
+      }
+    }
+  }
+}
+
+/**
+ * Evaluate a standalone expression string against an environment.
+ * Returns null if it doesn't fully parse and evaluate to a finite number.
+ */
+export function evaluateExpression(
+  src: string,
+  env: ReadonlyMap<string, number>
+): number | null {
+  const tokens = tokenize(src, 0);
+  if (tokens === null || tokens.length === 0) return null;
+  try {
+    const value = evalNode(new Parser(tokens).parse(), env);
+    return Number.isFinite(value) ? value : null;
+  } catch (error) {
+    if (error instanceof MathError) return null;
+    throw error;
+  }
+}
+
+// --- Result formatting -------------------------------------------------------
+
+/**
+ * Format a result like the Apple Notes reference: space-grouped thousands
+ * (`62 914 560 000`), float noise removed (0.1+0.2 → "0.3"), locale-independent.
+ * Extreme magnitudes fall back to JS exponential notation.
+ */
+export function formatResult(value: number): string {
+  let v = Number(value.toPrecision(12));
+  if (Object.is(v, -0)) v = 0;
+  const str = String(v);
+  if (str.includes('e') || str.includes('E')) return str;
+  const negative = str.startsWith('-');
+  const body = negative ? str.slice(1) : str;
+  const [intPart, fracPart] = body.split('.');
+  const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+  return (negative ? '-' : '') + grouped + (fracPart !== undefined ? '.' + fracPart : '');
+}
+
+// --- Document analysis -------------------------------------------------------
+
+const LIST_MARKER_RE = /^\s*(?:[-*+]|\d+[.)])\s+/;
+
+/**
+ * Analyze a whole note body top-to-bottom with a single variable environment
+ * (nearest definition above a line wins; forward references are undefined).
+ * Returns one entry per input line: a MathLineResult for lines that fully
+ * parse AND evaluate to a finite value, null otherwise (silent failure).
+ * Skips YAML frontmatter, fenced code blocks, lines containing backticks,
+ * and everything from the first '#' (comments; also excludes headings).
+ */
+export function analyzeDocument(lines: readonly string[]): Array<MathLineResult | null> {
+  const results: Array<MathLineResult | null> = new Array(lines.length).fill(null);
+  const env = new Map<string, number>();
+
+  // Frontmatter: only a leading '---' with a matching closer counts
+  // (same semantics as tagPlugin's isInFrontmatter).
+  let skipThrough = -1;
+  if (lines[0] === '---') {
+    for (let i = 1; i < lines.length; i++) {
+      if (lines[i] === '---') {
+        skipThrough = i;
+        break;
+      }
+    }
+  }
+
+  let inFence = false;
+  for (let i = 0; i < lines.length; i++) {
+    if (i <= skipThrough) continue;
+    const line = lines[i];
+    if (line.startsWith('```')) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence || line.includes('`')) continue;
+
+    // Strip one leading list marker so math works inside lists; keep the
+    // offset so spans map back to real columns. `- [ ] task` still fails
+    // later because '[' doesn't tokenize.
+    const markerMatch = LIST_MARKER_RE.exec(line);
+    const base = markerMatch ? markerMatch[0].length : 0;
+    // Everything from the first '#' is a comment. This also rejects headings
+    // and comment-only lines (nothing remains before the '#').
+    const hashIndex = line.indexOf('#', base);
+    const text = line.slice(base, hashIndex === -1 ? line.length : hashIndex);
+    if (!text.includes('=')) continue;
+
+    const tokens = tokenize(text, base);
+    if (tokens === null || tokens.length === 0) continue;
+
+    // Trailing '=' means "show me the result".
+    let resultOffset: number | undefined;
+    const last = tokens[tokens.length - 1];
+    if (last.type === 'op' && last.op === '=') {
+      tokens.pop();
+      resultOffset = last.to;
+    }
+    if (tokens.length === 0) continue;
+
+    // `Name = expr...` is a definition; anything else must be a bare
+    // expression on an evaluation line.
+    let nameToken: IdentToken | undefined;
+    let exprTokens: readonly Token[] = tokens;
+    const [first, second] = tokens;
+    if (
+      tokens.length > 2 &&
+      first.type === 'ident' &&
+      second.type === 'op' &&
+      second.op === '='
+    ) {
+      nameToken = first;
+      exprTokens = tokens.slice(2);
+    } else if (resultOffset === undefined) {
+      continue;
+    }
+
+    const parser = new Parser(exprTokens);
+    let value: number;
+    try {
+      value = evalNode(parser.parse(), env);
+    } catch (error) {
+      if (error instanceof MathError) continue;
+      throw error;
+    }
+    if (!Number.isFinite(value)) continue;
+
+    const result: MathLineResult = {
+      kind: nameToken === undefined ? 'evaluation' : 'definition',
+      refSpans: parser.varNodes.map((node) => node.span),
+      value,
+    };
+    if (nameToken !== undefined) {
+      env.set(nameToken.name, value);
+      result.nameSpan = { from: nameToken.from, to: nameToken.to };
+    }
+    if (resultOffset !== undefined) {
+      if (nameToken !== undefined) result.kind = 'definition-evaluation';
+      result.resultText = formatResult(value);
+      result.resultOffset = resultOffset;
+    }
+    results[i] = result;
+  }
+
+  return results;
+}

--- a/src/utils/mathEvaluator.ts
+++ b/src/utils/mathEvaluator.ts
@@ -214,6 +214,17 @@ const SUFFIX_MULTIPLIER: Record<string, number> = {
   T: 1e12,
 };
 
+// Spelled-out multipliers fold into a preceding number literal
+// (`32 Billion` = 3.2e10), case-insensitively, before any unit attaches —
+// so `3 Million MB` is 3 TB.
+const WORD_MULTIPLIERS: Record<string, number> = {
+  hundred: 100,
+  thousand: 1e3,
+  million: 1e6,
+  billion: 1e9,
+  trillion: 1e12,
+};
+
 const IDENT_START = /[A-Za-z_]/;
 const IDENT_CHAR = /[A-Za-z0-9_]/;
 const HEX_RE = /^0[xX][0-9a-fA-F]+/;
@@ -504,10 +515,22 @@ class Parser {
     if (token === undefined) throw new MathError('unexpected end of expression');
     if (token.type === 'num') {
       this.pos++;
+      let value = token.value;
+      let end = token.to;
+      const wordToken = this.peek();
+      if (
+        wordToken?.type === 'ident' &&
+        wordToken.from - end <= 1 &&
+        WORD_MULTIPLIERS[wordToken.name.toLowerCase()] !== undefined
+      ) {
+        this.pos++;
+        value *= WORD_MULTIPLIERS[wordToken.name.toLowerCase()];
+        end = wordToken.to;
+      }
       const unitToken = this.peek();
       if (
         unitToken?.type === 'ident' &&
-        unitToken.from - token.to <= 1 &&
+        unitToken.from - end <= 1 &&
         UNITS[unitToken.name] !== undefined
       ) {
         this.pos++;
@@ -516,13 +539,13 @@ class Parser {
         if (divisor) {
           return {
             kind: 'quantity',
-            value: (token.value * unit.factor) / divisor.spec.factor,
+            value: (value * unit.factor) / divisor.spec.factor,
             dim: dimCombine(unit.dim, divisor.spec.dim, -1),
           };
         }
-        return { kind: 'quantity', value: token.value * unit.factor, dim: unit.dim };
+        return { kind: 'quantity', value: value * unit.factor, dim: unit.dim };
       }
-      return { kind: 'num', value: token.value };
+      return { kind: 'num', value };
     }
     if (token.type === 'ident') {
       this.pos++;

--- a/src/utils/mathEvaluator.ts
+++ b/src/utils/mathEvaluator.ts
@@ -2,8 +2,16 @@
 //
 // A line like `Params = 32×10^9` defines a variable; a line with a trailing
 // `=` (e.g. `ModelSize =` or `2 + (3 × 4) =`) is a request to evaluate the
-// expression before it. Lines that don't fully parse AND evaluate to a finite
-// number are silently ignored (`Deadline = Friday` stays plain prose).
+// expression before it. Lines that don't fully parse AND evaluate are
+// silently ignored (`Deadline = Friday` stays plain prose).
+//
+// Values are quantities: a magnitude plus a dimension vector, so unit math
+// works dimensionally — `6kJ/s =` shows `6 kW`, `8MB / 2s =` shows `4 MB/s`,
+// and `8MB + 2s` is a silent error. Also supported: thousands-separated
+// input (`16 000 000 000`), hex/bin literals (0xFF, 0b1010), `in`
+// conversions (`8MB in KiB =`, `255 in hex =`), percentages, k/M/G/T scale
+// suffixes on bare numbers, functions (trig in degrees), and the constants
+// pi and e (shadowable by user definitions).
 //
 // Pure module: no CodeMirror, DOM, or Tauri imports. The editor integration
 // lives in src/components/editor/mathPlugin.ts.
@@ -22,13 +30,150 @@ export interface MathLineResult {
   nameSpan?: MathSpan;
   /** Spans of variable references in the expression (all resolved, since the line evaluated). */
   refSpans: MathSpan[];
-  /** Computed value (always finite). */
+  /** Computed magnitude in base units (B, s, J, m, g); always finite. */
   value: number;
   /** Formatted result text; present for 'evaluation' and 'definition-evaluation'. */
   resultText?: string;
   /** Column just after the trailing '='; widget insertion point. */
   resultOffset?: number;
 }
+
+// --- Dimensions and quantities -----------------------------------------------
+
+interface Dim {
+  data: number;
+  time: number;
+  energy: number;
+  length: number;
+  mass: number;
+}
+
+interface Quantity {
+  value: number;
+  dim: Dim;
+}
+
+const DIMLESS: Dim = { data: 0, time: 0, energy: 0, length: 0, mass: 0 };
+
+function dim(partial: Partial<Dim>): Dim {
+  return { ...DIMLESS, ...partial };
+}
+
+function dimCombine(a: Dim, b: Dim, sign: 1 | -1): Dim {
+  return {
+    data: a.data + sign * b.data,
+    time: a.time + sign * b.time,
+    energy: a.energy + sign * b.energy,
+    length: a.length + sign * b.length,
+    mass: a.mass + sign * b.mass,
+  };
+}
+
+function dimEq(a: Dim, b: Dim): boolean {
+  return (
+    a.data === b.data &&
+    a.time === b.time &&
+    a.energy === b.energy &&
+    a.length === b.length &&
+    a.mass === b.mass
+  );
+}
+
+function isDimless(d: Dim): boolean {
+  return dimEq(d, DIMLESS);
+}
+
+function dimKey(d: Dim): string {
+  return `${d.data},${d.time},${d.energy},${d.length},${d.mass}`;
+}
+
+// --- Unit tables --------------------------------------------------------------
+
+interface UnitSpec {
+  /** Multiplier to the dimension's base unit (B, s, J, m, g). */
+  factor: number;
+  dim: Dim;
+}
+
+const DATA = dim({ data: 1 });
+const TIME = dim({ time: 1 });
+const ENERGY = dim({ energy: 1 });
+const POWER = dim({ energy: 1, time: -1 });
+const LENGTH = dim({ length: 1 });
+const MASS = dim({ mass: 1 });
+const FREQUENCY = dim({ time: -1 });
+
+// Flat table (no prefix parsing) so collisions stay explicit — e.g. `ms` is
+// milliseconds, never meter·something; `min` is minutes here but still the
+// function in call position and a plain variable on an LHS.
+const UNITS: Record<string, UnitSpec> = {
+  B: { factor: 1, dim: DATA },
+  kB: { factor: 1e3, dim: DATA },
+  KB: { factor: 1e3, dim: DATA },
+  MB: { factor: 1e6, dim: DATA },
+  GB: { factor: 1e9, dim: DATA },
+  TB: { factor: 1e12, dim: DATA },
+  KiB: { factor: 1024, dim: DATA },
+  kiB: { factor: 1024, dim: DATA },
+  MiB: { factor: 1024 ** 2, dim: DATA },
+  GiB: { factor: 1024 ** 3, dim: DATA },
+  TiB: { factor: 1024 ** 4, dim: DATA },
+  // Lowercase b is bits, networking-style: 8Mb = 1 MB.
+  b: { factor: 0.125, dim: DATA },
+  kb: { factor: 125, dim: DATA },
+  Kb: { factor: 125, dim: DATA },
+  Mb: { factor: 125e3, dim: DATA },
+  Gb: { factor: 125e6, dim: DATA },
+  Tb: { factor: 125e9, dim: DATA },
+  bit: { factor: 0.125, dim: DATA },
+  kbit: { factor: 125, dim: DATA },
+  Mbit: { factor: 125e3, dim: DATA },
+  Gbit: { factor: 125e6, dim: DATA },
+  ms: { factor: 1e-3, dim: TIME },
+  s: { factor: 1, dim: TIME },
+  min: { factor: 60, dim: TIME },
+  h: { factor: 3600, dim: TIME },
+  d: { factor: 86400, dim: TIME },
+  J: { factor: 1, dim: ENERGY },
+  kJ: { factor: 1e3, dim: ENERGY },
+  MJ: { factor: 1e6, dim: ENERGY },
+  GJ: { factor: 1e9, dim: ENERGY },
+  Wh: { factor: 3600, dim: ENERGY },
+  kWh: { factor: 3.6e6, dim: ENERGY },
+  MWh: { factor: 3.6e9, dim: ENERGY },
+  mW: { factor: 1e-3, dim: POWER },
+  W: { factor: 1, dim: POWER },
+  kW: { factor: 1e3, dim: POWER },
+  MW: { factor: 1e6, dim: POWER },
+  GW: { factor: 1e9, dim: POWER },
+  mm: { factor: 1e-3, dim: LENGTH },
+  cm: { factor: 1e-2, dim: LENGTH },
+  m: { factor: 1, dim: LENGTH },
+  km: { factor: 1e3, dim: LENGTH },
+  mg: { factor: 1e-3, dim: MASS },
+  g: { factor: 1, dim: MASS },
+  kg: { factor: 1e3, dim: MASS },
+  Hz: { factor: 1, dim: FREQUENCY },
+  kHz: { factor: 1e3, dim: FREQUENCY },
+  MHz: { factor: 1e6, dim: FREQUENCY },
+  GHz: { factor: 1e9, dim: FREQUENCY },
+};
+
+// Auto-scaled display: for a result's dimension, pick the largest unit the
+// magnitude reaches (ascending factors; falls back to the smallest).
+// Dimensions without a family here render nothing (silent), unless the user
+// converts explicitly with `in`.
+const DISPLAY_FAMILIES = new Map<string, Array<[label: string, factor: number]>>([
+  [dimKey(DATA), [['B', 1], ['kB', 1e3], ['MB', 1e6], ['GB', 1e9], ['TB', 1e12]]],
+  [dimKey(TIME), [['ms', 1e-3], ['s', 1], ['min', 60], ['h', 3600], ['d', 86400]]],
+  [dimKey(ENERGY), [['J', 1], ['kJ', 1e3], ['MJ', 1e6], ['GJ', 1e9]]],
+  [dimKey(POWER), [['mW', 1e-3], ['W', 1], ['kW', 1e3], ['MW', 1e6], ['GW', 1e9]]],
+  [dimKey(LENGTH), [['mm', 1e-3], ['m', 1], ['km', 1e3]]],
+  [dimKey(MASS), [['mg', 1e-3], ['g', 1], ['kg', 1e3]]],
+  [dimKey(FREQUENCY), [['Hz', 1], ['kHz', 1e3], ['MHz', 1e6], ['GHz', 1e9]]],
+  [dimKey(dim({ data: 1, time: -1 })), [['B/s', 1], ['kB/s', 1e3], ['MB/s', 1e6], ['GB/s', 1e9], ['TB/s', 1e12]]],
+  [dimKey(dim({ length: 1, time: -1 })), [['m/s', 1]]],
+]);
 
 // --- Tokenizer ---------------------------------------------------------------
 
@@ -58,9 +203,9 @@ const OP_NORMALIZE: Record<string, OpChar> = {
   '=': '=',
 };
 
-// Suffixes are only recognized when not followed by an identifier character
-// (so `8km` and `8k2` fall through to a parse error). Lowercase m/g/t are
-// deliberately rejected: they read as milli/grams/tonnes in prose.
+// Bare scale suffixes (`8k`, `32G`) apply only when the next char is not an
+// identifier char — `8kB` falls through to the ident lexer and becomes a
+// unit. Lowercase m/g/t are never scale suffixes (milli/grams/tonnes prose).
 const SUFFIX_MULTIPLIER: Record<string, number> = {
   k: 1e3,
   K: 1e3,
@@ -71,7 +216,9 @@ const SUFFIX_MULTIPLIER: Record<string, number> = {
 
 const IDENT_START = /[A-Za-z_]/;
 const IDENT_CHAR = /[A-Za-z0-9_]/;
-const NUMBER_RE = /^(?:\d+(?:\.\d+)?|\.\d+)/;
+const HEX_RE = /^0[xX][0-9a-fA-F]+/;
+const BIN_RE = /^0[bB][01]+/;
+const DIGIT_RE = /[0-9]/;
 
 /**
  * Tokenize expression text. Token positions are offset by `base` so they map
@@ -87,10 +234,43 @@ function tokenize(text: string, base: number): Token[] | null {
       i++;
       continue;
     }
-    const numMatch = NUMBER_RE.exec(text.slice(i));
-    if (numMatch) {
-      let end = i + numMatch[0].length;
-      let value = Number(numMatch[0]);
+    if (DIGIT_RE.test(ch) || (ch === '.' && i + 1 < text.length && DIGIT_RE.test(text[i + 1]))) {
+      const rest = text.slice(i);
+      const radixMatch = HEX_RE.exec(rest) ?? BIN_RE.exec(rest);
+      if (radixMatch) {
+        tokens.push({
+          type: 'num',
+          value: Number(radixMatch[0]),
+          from: base + i,
+          to: base + i + radixMatch[0].length,
+        });
+        i += radixMatch[0].length;
+        continue;
+      }
+      let end = i;
+      let digits: string;
+      if (ch === '.') {
+        const fracMatch = /^\.\d+/.exec(rest)!;
+        digits = fracMatch[0];
+        end += fracMatch[0].length;
+      } else {
+        const intMatch = /^\d+/.exec(rest)!;
+        digits = intMatch[0];
+        end += intMatch[0].length;
+        // Thousands-separated input: merge ` ddd` groups (single space,
+        // exactly three digits, not followed by a fourth).
+        let group;
+        while (text[end] === ' ' && (group = /^\d{3}(?!\d)/.exec(text.slice(end + 1)))) {
+          digits += group[0];
+          end += 4;
+        }
+        const fracMatch = /^\.\d+/.exec(text.slice(end));
+        if (fracMatch) {
+          digits += fracMatch[0];
+          end += fracMatch[0].length;
+        }
+      }
+      let value = Number(digits);
       const suffix = text[end];
       if (
         suffix !== undefined &&
@@ -126,6 +306,7 @@ function tokenize(text: string, base: number): Token[] | null {
 
 type AstNode =
   | { kind: 'num'; value: number }
+  | { kind: 'quantity'; value: number; dim: Dim }
   | { kind: 'var'; name: string; span: MathSpan }
   | { kind: 'call'; name: string; args: AstNode[] }
   | { kind: 'binary'; op: '+' | '-' | '*' | '/' | '^'; left: AstNode; right: AstNode }
@@ -137,11 +318,18 @@ type AstNode =
   // 100 + (20%) is plain addition of 0.2, not a 20% increase.
   | { kind: 'group'; operand: AstNode };
 
+/** Display override requested with `expr in <target>`. */
+type Conversion =
+  | { type: 'unit'; text: string; factor: number; dim: Dim }
+  | { type: 'radix'; radix: 16 | 2 };
+
 interface FunctionSpec {
   minArity: number;
   maxArity: number;
   apply: (args: number[]) => number;
 }
+
+const DEG = Math.PI / 180;
 
 const FUNCTIONS: Record<string, FunctionSpec> = {
   sqrt: { minArity: 1, maxArity: 1, apply: ([x]) => Math.sqrt(x) },
@@ -151,26 +339,40 @@ const FUNCTIONS: Record<string, FunctionSpec> = {
   ceil: { minArity: 1, maxArity: 1, apply: ([x]) => Math.ceil(x) },
   log2: { minArity: 1, maxArity: 1, apply: ([x]) => Math.log2(x) },
   log10: { minArity: 1, maxArity: 1, apply: ([x]) => Math.log10(x) },
+  ln: { minArity: 1, maxArity: 1, apply: ([x]) => Math.log(x) },
+  exp: { minArity: 1, maxArity: 1, apply: ([x]) => Math.exp(x) },
+  pow: { minArity: 2, maxArity: 2, apply: ([x, y]) => Math.pow(x, y) },
+  // Trig works in degrees — sin(30) = 0.5, like calculator apps.
+  sin: { minArity: 1, maxArity: 1, apply: ([x]) => Math.sin(x * DEG) },
+  cos: { minArity: 1, maxArity: 1, apply: ([x]) => Math.cos(x * DEG) },
+  tan: { minArity: 1, maxArity: 1, apply: ([x]) => Math.tan(x * DEG) },
+  asin: { minArity: 1, maxArity: 1, apply: ([x]) => Math.asin(x) / DEG },
+  acos: { minArity: 1, maxArity: 1, apply: ([x]) => Math.acos(x) / DEG },
+  atan: { minArity: 1, maxArity: 1, apply: ([x]) => Math.atan(x) / DEG },
   min: { minArity: 1, maxArity: Infinity, apply: (args) => Math.min(...args) },
   max: { minArity: 1, maxArity: Infinity, apply: (args) => Math.max(...args) },
 };
 
+type VarNode = Extract<AstNode, { kind: 'var' }>;
+type IdentToken = Extract<Token, { type: 'ident' }>;
+
 /**
  * Recursive-descent parser over a token slice. Grammar (precedence low→high):
  *
- *   expr           := additive
+ *   top            := additive ("in" (unit | "hex" | "bin"))?
  *   additive       := multiplicative (("+"|"-") multiplicative)*   left-assoc
  *   multiplicative := unary (("*"|"/") unary)*                     left-assoc
  *   unary          := ("-"|"+") unary | power
  *   power          := postfix ("^" unary)?                         right-assoc
  *   postfix        := primary "%"?                                 % after number literals only
- *   primary        := NUMBER | IDENT | IDENT "(" expr ("," expr)* ")" | "(" expr ")"
+ *   primary        := NUMBER unit? | IDENT | IDENT "(" args ")" | "(" expr ")"
+ *   unit           := UNIT-IDENT ("/" UNIT-IDENT)?                 attached to the number
+ *                                                                  (≤1 space; rate "/" must be tight)
  *
- * No implicit multiplication: adjacent operands are a parse error.
+ * No implicit multiplication: adjacent operands are a parse error. In unit
+ * position a known unit name wins over any same-named variable, so `6kJ/s`
+ * stays a rate even if `s` is defined.
  */
-type VarNode = Extract<AstNode, { kind: 'var' }>;
-type IdentToken = Extract<Token, { type: 'ident' }>;
-
 class Parser {
   private pos = 0;
   private readonly tokens: readonly Token[];
@@ -180,12 +382,56 @@ class Parser {
     this.tokens = tokens;
   }
 
-  /** Parse the whole token slice as one expression; throws MathError on failure. */
-  parse(): AstNode {
+  /** Parse the whole token slice as one expression with an optional `in` conversion. */
+  parseTop(): { node: AstNode; conversion: Conversion | null } {
     if (this.tokens.length === 0) throw new MathError('empty expression');
     const node = this.parseAdditive();
+    let conversion: Conversion | null = null;
+    const next = this.peek();
+    if (next?.type === 'ident' && next.name === 'in') {
+      this.pos++;
+      conversion = this.parseConversionTarget();
+    }
     if (this.pos !== this.tokens.length) throw new MathError('unexpected trailing tokens');
-    return node;
+    return { node, conversion };
+  }
+
+  private parseConversionTarget(): Conversion {
+    const token = this.peek();
+    if (token?.type !== 'ident') throw new MathError('expected conversion target');
+    this.pos++;
+    if (token.name === 'hex') return { type: 'radix', radix: 16 };
+    if (token.name === 'bin') return { type: 'radix', radix: 2 };
+    const unit = UNITS[token.name];
+    if (unit === undefined) throw new MathError(`unknown unit '${token.name}'`);
+    const divisor = this.tryParseRateDivisor(token.to);
+    if (divisor) {
+      return {
+        type: 'unit',
+        text: `${token.name}/${divisor.name}`,
+        factor: unit.factor / divisor.spec.factor,
+        dim: dimCombine(unit.dim, divisor.spec.dim, -1),
+      };
+    }
+    return { type: 'unit', text: token.name, factor: unit.factor, dim: unit.dim };
+  }
+
+  /** Consume a tight `/unit` (as in `kJ/s`) if present; never consumes on failure. */
+  private tryParseRateDivisor(endOfPrev: number): { name: string; spec: UnitSpec } | null {
+    const slash = this.tokens[this.pos];
+    const unitToken = this.tokens[this.pos + 1];
+    if (
+      slash?.type === 'op' &&
+      slash.op === '/' &&
+      slash.from === endOfPrev &&
+      unitToken?.type === 'ident' &&
+      unitToken.from === slash.to &&
+      UNITS[unitToken.name] !== undefined
+    ) {
+      this.pos += 2;
+      return { name: unitToken.name, spec: UNITS[unitToken.name] };
+    }
+    return null;
   }
 
   private peek(): Token | undefined {
@@ -258,6 +504,24 @@ class Parser {
     if (token === undefined) throw new MathError('unexpected end of expression');
     if (token.type === 'num') {
       this.pos++;
+      const unitToken = this.peek();
+      if (
+        unitToken?.type === 'ident' &&
+        unitToken.from - token.to <= 1 &&
+        UNITS[unitToken.name] !== undefined
+      ) {
+        this.pos++;
+        const unit = UNITS[unitToken.name];
+        const divisor = this.tryParseRateDivisor(unitToken.to);
+        if (divisor) {
+          return {
+            kind: 'quantity',
+            value: (token.value * unit.factor) / divisor.spec.factor,
+            dim: dimCombine(unit.dim, divisor.spec.dim, -1),
+          };
+        }
+        return { kind: 'quantity', value: token.value * unit.factor, dim: unit.dim };
+      }
       return { kind: 'num', value: token.value };
     }
     if (token.type === 'ident') {
@@ -292,19 +556,28 @@ class Parser {
 
 // --- Evaluator ---------------------------------------------------------------
 
-function evalNode(node: AstNode, env: ReadonlyMap<string, number>): number {
+function requireDimless(q: Quantity): number {
+  if (!isDimless(q.dim)) throw new MathError('expected a dimensionless value');
+  return q.value;
+}
+
+function evalNode(node: AstNode, env: ReadonlyMap<string, Quantity>): Quantity {
   switch (node.kind) {
     case 'num':
-      return node.value;
+      return { value: node.value, dim: DIMLESS };
+    case 'quantity':
+      return { value: node.value, dim: node.dim };
     case 'var': {
       const value = env.get(node.name);
       if (value === undefined) throw new MathError(`undefined variable '${node.name}'`);
       return value;
     }
     case 'percent':
-      return evalNode(node.operand, env) / 100;
-    case 'neg':
-      return -evalNode(node.operand, env);
+      return { value: evalNode(node.operand, env).value / 100, dim: DIMLESS };
+    case 'neg': {
+      const operand = evalNode(node.operand, env);
+      return { value: -operand.value, dim: operand.dim };
+    }
     case 'group':
       return evalNode(node.operand, env);
     case 'call': {
@@ -313,7 +586,8 @@ function evalNode(node: AstNode, env: ReadonlyMap<string, number>): number {
       if (node.args.length < fn.minArity || node.args.length > fn.maxArity) {
         throw new MathError(`wrong arity for '${node.name}'`);
       }
-      return fn.apply(node.args.map((arg) => evalNode(arg, env)));
+      const args = node.args.map((arg) => requireDimless(evalNode(arg, env)));
+      return { value: fn.apply(args), dim: DIMLESS };
     }
     case 'binary': {
       const left = evalNode(node.left, env);
@@ -321,29 +595,33 @@ function evalNode(node: AstNode, env: ReadonlyMap<string, number>): number {
       // Only when the right operand is literally a percent node — products,
       // groups, and variables holding percent-derived values stay plain.
       if ((node.op === '+' || node.op === '-') && node.right.kind === 'percent') {
-        const fraction = evalNode(node.right, env);
-        return node.op === '+' ? left * (1 + fraction) : left * (1 - fraction);
+        const fraction = evalNode(node.right, env).value;
+        const scaled = node.op === '+' ? 1 + fraction : 1 - fraction;
+        return { value: left.value * scaled, dim: left.dim };
       }
       const right = evalNode(node.right, env);
       switch (node.op) {
         case '+':
-          return left + right;
-        case '-':
-          return left - right;
+        case '-': {
+          if (!dimEq(left.dim, right.dim)) throw new MathError('mismatched units');
+          const value = node.op === '+' ? left.value + right.value : left.value - right.value;
+          return { value, dim: left.dim };
+        }
         case '*':
-          return left * right;
+          return { value: left.value * right.value, dim: dimCombine(left.dim, right.dim, 1) };
         case '/':
-          return left / right;
+          return { value: left.value / right.value, dim: dimCombine(left.dim, right.dim, -1) };
         case '^':
-          return Math.pow(left, right);
+          return { value: Math.pow(requireDimless(left), requireDimless(right)), dim: DIMLESS };
       }
     }
   }
 }
 
 /**
- * Evaluate a standalone expression string against an environment.
- * Returns null if it doesn't fully parse and evaluate to a finite number.
+ * Evaluate a standalone expression string against an environment of plain
+ * (dimensionless) numbers. Returns the magnitude in base units, or null if
+ * the expression doesn't fully parse and evaluate to a finite number.
  */
 export function evaluateExpression(
   src: string,
@@ -351,9 +629,12 @@ export function evaluateExpression(
 ): number | null {
   const tokens = tokenize(src, 0);
   if (tokens === null || tokens.length === 0) return null;
+  const quantities = new Map<string, Quantity>();
+  for (const [name, value] of env) quantities.set(name, { value, dim: DIMLESS });
   try {
-    const value = evalNode(new Parser(tokens).parse(), env);
-    return Number.isFinite(value) ? value : null;
+    const { node } = new Parser(tokens).parseTop();
+    const result = evalNode(node, quantities);
+    return Number.isFinite(result.value) ? result.value : null;
   } catch (error) {
     if (error instanceof MathError) return null;
     throw error;
@@ -363,9 +644,9 @@ export function evaluateExpression(
 // --- Result formatting -------------------------------------------------------
 
 /**
- * Format a result like the Apple Notes reference: space-grouped thousands
- * (`62 914 560 000`), float noise removed (0.1+0.2 → "0.3"), locale-independent.
- * Extreme magnitudes fall back to JS exponential notation.
+ * Format a plain number like the Apple Notes reference: space-grouped
+ * thousands (`62 914 560 000`), float noise removed (0.1+0.2 → "0.3"),
+ * locale-independent. Extreme magnitudes fall back to JS exponential.
  */
 export function formatResult(value: number): string {
   let v = Number(value.toPrecision(12));
@@ -379,9 +660,44 @@ export function formatResult(value: number): string {
   return (negative ? '-' : '') + grouped + (fracPart !== undefined ? '.' + fracPart : '');
 }
 
+/**
+ * Format a quantity for display, honoring an `in` conversion if given.
+ * Returns null when there is no meaningful rendering (unknown dimension
+ * combination, conversion dimension mismatch, hex/bin of a non-integer).
+ */
+function formatQuantity(q: Quantity, conversion: Conversion | null): string | null {
+  if (conversion?.type === 'radix') {
+    if (!isDimless(q.dim)) return null;
+    const v = Number(q.value.toPrecision(12));
+    if (!Number.isSafeInteger(v)) return null;
+    const digits = Math.abs(v).toString(conversion.radix).toUpperCase();
+    const prefix = conversion.radix === 16 ? '0x' : '0b';
+    return `${v < 0 ? '-' : ''}${prefix}${digits}`;
+  }
+  if (conversion?.type === 'unit') {
+    if (!dimEq(q.dim, conversion.dim)) return null;
+    return `${formatResult(q.value / conversion.factor)} ${conversion.text}`;
+  }
+  if (isDimless(q.dim)) return formatResult(q.value);
+  const family = DISPLAY_FAMILIES.get(dimKey(q.dim));
+  if (family === undefined) return null;
+  const magnitude = Math.abs(q.value);
+  let best = family[0];
+  for (const entry of family) {
+    if (magnitude >= entry[1]) best = entry;
+  }
+  return `${formatResult(q.value / best[1])} ${best[0]}`;
+}
+
 // --- Document analysis -------------------------------------------------------
 
 const LIST_MARKER_RE = /^\s*(?:[-*+]|\d+[.)])\s+/;
+
+/** Built-in constants, seeded into scope; user definitions shadow them. */
+const CONSTANTS: ReadonlyArray<[string, number]> = [
+  ['pi', Math.PI],
+  ['e', Math.E],
+];
 
 /**
  * Analyze a whole note body top-to-bottom with a single variable environment
@@ -393,7 +709,8 @@ const LIST_MARKER_RE = /^\s*(?:[-*+]|\d+[.)])\s+/;
  */
 export function analyzeDocument(lines: readonly string[]): Array<MathLineResult | null> {
   const results: Array<MathLineResult | null> = new Array(lines.length).fill(null);
-  const env = new Map<string, number>();
+  const env = new Map<string, Quantity>();
+  for (const [name, value] of CONSTANTS) env.set(name, { value, dim: DIMLESS });
 
   // Frontmatter: only a leading '---' with a matching closer counts
   // (same semantics as tagPlugin's isInFrontmatter).
@@ -458,27 +775,36 @@ export function analyzeDocument(lines: readonly string[]): Array<MathLineResult 
     }
 
     const parser = new Parser(exprTokens);
-    let value: number;
+    let quantity: Quantity;
+    let conversion: Conversion | null;
     try {
-      value = evalNode(parser.parse(), env);
+      const parsed = parser.parseTop();
+      conversion = parsed.conversion;
+      quantity = evalNode(parsed.node, env);
     } catch (error) {
       if (error instanceof MathError) continue;
       throw error;
     }
-    if (!Number.isFinite(value)) continue;
+    if (!Number.isFinite(quantity.value)) continue;
+
+    const resultText = resultOffset === undefined ? null : formatQuantity(quantity, conversion);
+    // An evaluation request we can't render meaningfully stays inert; a
+    // definition still defines (its dimension may only combine usefully
+    // later), it just shows no ghost result.
+    if (nameToken === undefined && resultText === null) continue;
 
     const result: MathLineResult = {
       kind: nameToken === undefined ? 'evaluation' : 'definition',
       refSpans: parser.varNodes.map((node) => node.span),
-      value,
+      value: quantity.value,
     };
     if (nameToken !== undefined) {
-      env.set(nameToken.name, value);
+      env.set(nameToken.name, quantity);
       result.nameSpan = { from: nameToken.from, to: nameToken.to };
     }
-    if (resultOffset !== undefined) {
+    if (resultText !== null && resultOffset !== undefined) {
       if (nameToken !== undefined) result.kind = 'definition-evaluation';
-      result.resultText = formatResult(value);
+      result.resultText = resultText;
       result.resultOffset = resultOffset;
     }
     results[i] = result;

--- a/src/utils/mathEvaluator.ts
+++ b/src/utils/mathEvaluator.ts
@@ -424,13 +424,22 @@ type IdentToken = Extract<Token, { type: 'ident' }>;
  * position a known unit name wins over any same-named variable, so `6kJ/s`
  * stays a rate even if `s` is defined.
  */
+const NO_ALIASES: ReadonlyMap<string, string> = new Map();
+
 class Parser {
   private pos = 0;
   private readonly tokens: readonly Token[];
+  private readonly currencyAliases: ReadonlyMap<string, string>;
   readonly varNodes: VarNode[] = [];
 
-  constructor(tokens: readonly Token[]) {
+  constructor(tokens: readonly Token[], currencyAliases: ReadonlyMap<string, string> = NO_ALIASES) {
     this.tokens = tokens;
+    this.currencyAliases = currencyAliases;
+  }
+
+  /** Apply `$ = USD`-style notation aliases to a currency marker. */
+  private resolveTag(marker: string): string {
+    return this.currencyAliases.get(marker) ?? marker;
   }
 
   /** Parse the whole token slice as one expression with an optional `in` conversion. */
@@ -474,7 +483,7 @@ class Parser {
     const unit = UNITS[name];
     if (unit !== undefined) return { factor: unit.factor, dim: unit.dim, code: null };
     const code = resolveCurrencyCode(name);
-    if (code !== null) return { factor: 1, dim: MONEY, code };
+    if (code !== null) return { factor: 1, dim: MONEY, code: this.resolveTag(code) };
     return null;
   }
 
@@ -636,7 +645,7 @@ class Parser {
     if (token.type === 'cursym') {
       // Prefix symbol form: $320 (optionally $3 Billion).
       this.pos++;
-      return this.parseMoneyAmount(token.code, token.to);
+      return this.parseMoneyAmount(this.resolveTag(token.code), token.to);
     }
     if (token.type === 'ident') {
       // Prefix code form: `kr 320`, `USD 100` — a currency name directly
@@ -645,7 +654,7 @@ class Parser {
       const next = this.tokens[this.pos + 1];
       if (prefixCode !== null && next?.type === 'num' && next.from - token.to <= 1) {
         this.pos++;
-        return this.parseMoneyAmount(prefixCode, token.to);
+        return this.parseMoneyAmount(this.resolveTag(prefixCode), token.to);
       }
       this.pos++;
       if (this.peekOp() === '(') {
@@ -894,6 +903,8 @@ export function analyzeDocument(lines: readonly string[]): Array<MathLineResult 
   const results: Array<MathLineResult | null> = new Array(lines.length).fill(null);
   const env = new Map<string, Quantity>();
   for (const [name, value] of CONSTANTS) env.set(name, { value, dim: DIMLESS, code: null });
+  // `$ = USD`-style notation aliases; scoped top-to-bottom like variables.
+  const currencyAliases = new Map<string, string>();
 
   // Frontmatter: only a leading '---' with a matching closer counts
   // (same semantics as tagPlugin's isInFrontmatter).
@@ -931,6 +942,34 @@ export function analyzeDocument(lines: readonly string[]): Array<MathLineResult 
     const tokens = tokenize(text, base);
     if (tokens === null || tokens.length === 0) continue;
 
+    // `$ = USD` assigns a currency notation: from here down the marker
+    // ($, €, £, ¥, kr) means that ISO code. Overridable further down.
+    if (tokens.length === 3) {
+      const [markerToken, eqToken, codeToken] = tokens;
+      const marker =
+        markerToken.type === 'cursym'
+          ? markerToken.code
+          : markerToken.type === 'ident' && markerToken.name === 'kr'
+            ? 'kr'
+            : null;
+      if (
+        marker !== null &&
+        eqToken.type === 'op' &&
+        eqToken.op === '=' &&
+        codeToken.type === 'ident' &&
+        CURRENCY_CODE_RE.test(codeToken.name)
+      ) {
+        currencyAliases.set(marker, codeToken.name);
+        results[i] = {
+          kind: 'definition',
+          nameSpan: { from: markerToken.from, to: markerToken.to },
+          refSpans: [{ from: codeToken.from, to: codeToken.to }],
+          value: 0,
+        };
+        continue;
+      }
+    }
+
     // Trailing '=' means "show me the result".
     let resultOffset: number | undefined;
     const last = tokens[tokens.length - 1];
@@ -957,7 +996,7 @@ export function analyzeDocument(lines: readonly string[]): Array<MathLineResult 
       continue;
     }
 
-    const parser = new Parser(exprTokens);
+    const parser = new Parser(exprTokens, currencyAliases);
     let quantity: Quantity;
     let conversion: Conversion | null;
     try {

--- a/src/utils/mathEvaluator.ts
+++ b/src/utils/mathEvaluator.ts
@@ -762,29 +762,6 @@ function evalNode(node: AstNode, env: ReadonlyMap<string, Quantity>): Quantity {
   }
 }
 
-/**
- * Evaluate a standalone expression string against an environment of plain
- * (dimensionless) numbers. Returns the magnitude in base units, or null if
- * the expression doesn't fully parse and evaluate to a finite number.
- */
-export function evaluateExpression(
-  src: string,
-  env: ReadonlyMap<string, number>
-): number | null {
-  const tokens = tokenize(src, 0);
-  if (tokens === null || tokens.length === 0) return null;
-  const quantities = new Map<string, Quantity>();
-  for (const [name, value] of env) quantities.set(name, { value, dim: DIMLESS, code: null });
-  try {
-    const { node } = new Parser(tokens).parseTop();
-    const result = evalNode(node, quantities);
-    return Number.isFinite(result.value) ? result.value : null;
-  } catch (error) {
-    if (error instanceof MathError) return null;
-    throw error;
-  }
-}
-
 // --- Result formatting -------------------------------------------------------
 
 /**
@@ -918,15 +895,21 @@ export function analyzeDocument(lines: readonly string[]): Array<MathLineResult 
     }
   }
 
-  let inFence = false;
+  // Fenced code: both ``` and ~~~ open a fence; only the same delimiter
+  // closes it (a ~~~ line inside a backtick fence is just content).
+  let fence: '```' | '~~~' | null = null;
   for (let i = 0; i < lines.length; i++) {
     if (i <= skipThrough) continue;
     const line = lines[i];
-    if (line.startsWith('```')) {
-      inFence = !inFence;
+    if (fence !== null) {
+      if (line.startsWith(fence)) fence = null;
       continue;
     }
-    if (inFence || line.includes('`')) continue;
+    if (line.startsWith('```') || line.startsWith('~~~')) {
+      fence = line.startsWith('```') ? '```' : '~~~';
+      continue;
+    }
+    if (line.includes('`')) continue;
 
     // Strip one leading list marker so math works inside lists; keep the
     // offset so spans map back to real columns. `- [ ] task` still fails

--- a/src/utils/mathEvaluator.ts
+++ b/src/utils/mathEvaluator.ts
@@ -46,14 +46,18 @@ interface Dim {
   energy: number;
   length: number;
   mass: number;
+  currency: number;
 }
 
 interface Quantity {
   value: number;
   dim: Dim;
+  /** ISO currency code; non-null iff dim.currency ≠ 0. There are no exchange
+   * rates — mixing codes is a silent error, same-code ratios cancel. */
+  code: string | null;
 }
 
-const DIMLESS: Dim = { data: 0, time: 0, energy: 0, length: 0, mass: 0 };
+const DIMLESS: Dim = { data: 0, time: 0, energy: 0, length: 0, mass: 0, currency: 0 };
 
 function dim(partial: Partial<Dim>): Dim {
   return { ...DIMLESS, ...partial };
@@ -66,6 +70,7 @@ function dimCombine(a: Dim, b: Dim, sign: 1 | -1): Dim {
     energy: a.energy + sign * b.energy,
     length: a.length + sign * b.length,
     mass: a.mass + sign * b.mass,
+    currency: a.currency + sign * b.currency,
   };
 }
 
@@ -75,7 +80,8 @@ function dimEq(a: Dim, b: Dim): boolean {
     a.time === b.time &&
     a.energy === b.energy &&
     a.length === b.length &&
-    a.mass === b.mass
+    a.mass === b.mass &&
+    a.currency === b.currency
   );
 }
 
@@ -84,7 +90,17 @@ function isDimless(d: Dim): boolean {
 }
 
 function dimKey(d: Dim): string {
-  return `${d.data},${d.time},${d.energy},${d.length},${d.mass}`;
+  return `${d.data},${d.time},${d.energy},${d.length},${d.mass},${d.currency}`;
+}
+
+/** Quantity constructor that keeps the code↔currency-exponent invariant. */
+function qty(value: number, dimension: Dim, code: string | null): Quantity {
+  return { value, dim: dimension, code: dimension.currency === 0 ? null : code };
+}
+
+function unifyCodes(a: string | null, b: string | null): string | null {
+  if (a !== null && b !== null && a !== b) throw new MathError('mixed currencies');
+  return a ?? b;
 }
 
 // --- Unit tables --------------------------------------------------------------
@@ -102,6 +118,23 @@ const POWER = dim({ energy: 1, time: -1 });
 const LENGTH = dim({ length: 1 });
 const MASS = dim({ mass: 1 });
 const FREQUENCY = dim({ time: -1 });
+const MONEY = dim({ currency: 1 });
+
+// Currencies attach after a number like units (`3200 NOK`, `320kr`), as a
+// word prefix (`kr 320`, `USD 100`), or as a symbol prefix (`$320`, `€50`).
+// The marker AS TYPED is the currency tag: $ only matches $, kr only kr,
+// NOK only NOK — a $ is not assumed to be USD, and there are no exchange
+// rates, so mixing tags is a silent error while same-tag ratios cancel.
+// Accepted markers: any ISO-4217-shaped code (three uppercase letters),
+// `kr`, and the symbols below.
+const CURRENCY_CODE_RE = /^[A-Z]{3}$/;
+
+function resolveCurrencyCode(name: string): string | null {
+  if (name === 'kr') return 'kr';
+  return CURRENCY_CODE_RE.test(name) ? name : null;
+}
+
+const CURRENCY_SYMBOLS = new Set(['$', '€', '£', '¥']);
 
 // Flat table (no prefix parsing) so collisions stay explicit — e.g. `ms` is
 // milliseconds, never meter·something; `min` is minutes here but still the
@@ -182,6 +215,7 @@ type OpChar = '+' | '-' | '*' | '/' | '^' | '%' | '(' | ')' | ',' | '=';
 type Token =
   | { type: 'num'; value: number; from: number; to: number }
   | { type: 'ident'; name: string; from: number; to: number }
+  | { type: 'cursym'; code: string; from: number; to: number }
   | { type: 'op'; op: OpChar; from: number; to: number };
 
 class MathError extends Error {}
@@ -308,6 +342,11 @@ function tokenize(text: string, base: number): Token[] | null {
       i++;
       continue;
     }
+    if (CURRENCY_SYMBOLS.has(ch)) {
+      tokens.push({ type: 'cursym', code: ch, from: base + i, to: base + i + 1 });
+      i++;
+      continue;
+    }
     return null;
   }
   return tokens;
@@ -317,7 +356,7 @@ function tokenize(text: string, base: number): Token[] | null {
 
 type AstNode =
   | { kind: 'num'; value: number }
-  | { kind: 'quantity'; value: number; dim: Dim }
+  | { kind: 'quantity'; value: number; dim: Dim; code: string | null }
   | { kind: 'var'; name: string; span: MathSpan }
   | { kind: 'call'; name: string; args: AstNode[] }
   | { kind: 'binary'; op: '+' | '-' | '*' | '/' | '^'; left: AstNode; right: AstNode }
@@ -331,7 +370,7 @@ type AstNode =
 
 /** Display override requested with `expr in <target>`. */
 type Conversion =
-  | { type: 'unit'; text: string; factor: number; dim: Dim }
+  | { type: 'unit'; text: string; factor: number; dim: Dim; code: string | null }
   | { type: 'radix'; radix: 16 | 2 };
 
 interface FunctionSpec {
@@ -376,8 +415,9 @@ type IdentToken = Extract<Token, { type: 'ident' }>;
  *   unary          := ("-"|"+") unary | power
  *   power          := postfix ("^" unary)?                         right-assoc
  *   postfix        := primary "%"?                                 % after number literals only
- *   primary        := NUMBER unit? | IDENT | IDENT "(" args ")" | "(" expr ")"
- *   unit           := UNIT-IDENT ("/" UNIT-IDENT)?                 attached to the number
+ *   primary        := NUMBER word-mult? unit? | CURRENCY-SYMBOL NUMBER word-mult?
+ *                   | IDENT | IDENT "(" args ")" | "(" expr ")"
+ *   unit           := (UNIT | CURRENCY) ("/" (UNIT | CURRENCY))?   attached to the number
  *                                                                  (≤1 space; rate "/" must be tight)
  *
  * No implicit multiplication: adjacent operands are a parse error. In unit
@@ -413,22 +453,35 @@ class Parser {
     this.pos++;
     if (token.name === 'hex') return { type: 'radix', radix: 16 };
     if (token.name === 'bin') return { type: 'radix', radix: 2 };
-    const unit = UNITS[token.name];
-    if (unit === undefined) throw new MathError(`unknown unit '${token.name}'`);
+    const base = this.resolveUnitOrCurrency(token.name);
+    if (base === null) throw new MathError(`unknown unit '${token.name}'`);
     const divisor = this.tryParseRateDivisor(token.to);
     if (divisor) {
       return {
         type: 'unit',
         text: `${token.name}/${divisor.name}`,
-        factor: unit.factor / divisor.spec.factor,
-        dim: dimCombine(unit.dim, divisor.spec.dim, -1),
+        factor: base.factor / divisor.factor,
+        dim: dimCombine(base.dim, divisor.dim, -1),
+        code: unifyCodes(base.code, divisor.code),
       };
     }
-    return { type: 'unit', text: token.name, factor: unit.factor, dim: unit.dim };
+    return { type: 'unit', text: token.name, factor: base.factor, dim: base.dim, code: base.code };
   }
 
-  /** Consume a tight `/unit` (as in `kJ/s`) if present; never consumes on failure. */
-  private tryParseRateDivisor(endOfPrev: number): { name: string; spec: UnitSpec } | null {
+  private resolveUnitOrCurrency(
+    name: string
+  ): { factor: number; dim: Dim; code: string | null } | null {
+    const unit = UNITS[name];
+    if (unit !== undefined) return { factor: unit.factor, dim: unit.dim, code: null };
+    const code = resolveCurrencyCode(name);
+    if (code !== null) return { factor: 1, dim: MONEY, code };
+    return null;
+  }
+
+  /** Consume a tight `/unit` (as in `kJ/s` or `GB/NOK`) if present; never consumes on failure. */
+  private tryParseRateDivisor(
+    endOfPrev: number
+  ): { name: string; factor: number; dim: Dim; code: string | null } | null {
     const slash = this.tokens[this.pos];
     const unitToken = this.tokens[this.pos + 1];
     if (
@@ -436,13 +489,46 @@ class Parser {
       slash.op === '/' &&
       slash.from === endOfPrev &&
       unitToken?.type === 'ident' &&
-      unitToken.from === slash.to &&
-      UNITS[unitToken.name] !== undefined
+      unitToken.from === slash.to
     ) {
-      this.pos += 2;
-      return { name: unitToken.name, spec: UNITS[unitToken.name] };
+      const resolved = this.resolveUnitOrCurrency(unitToken.name);
+      if (resolved !== null) {
+        this.pos += 2;
+        return { name: unitToken.name, ...resolved };
+      }
     }
     return null;
+  }
+
+  /** Consume `NUMBER word-mult? ("/" unit)?` after a currency prefix ($, kr, USD). */
+  private parseMoneyAmount(code: string, endOfPrefix: number): AstNode {
+    const numToken = this.peek();
+    if (numToken?.type !== 'num' || numToken.from - endOfPrefix > 1) {
+      throw new MathError(`expected a number after '${code}'`);
+    }
+    this.pos++;
+    let value = numToken.value;
+    let end = numToken.to;
+    const wordToken = this.peek();
+    if (
+      wordToken?.type === 'ident' &&
+      wordToken.from - end <= 1 &&
+      WORD_MULTIPLIERS[wordToken.name.toLowerCase()] !== undefined
+    ) {
+      this.pos++;
+      value *= WORD_MULTIPLIERS[wordToken.name.toLowerCase()];
+      end = wordToken.to;
+    }
+    const divisor = this.tryParseRateDivisor(end);
+    if (divisor) {
+      return {
+        kind: 'quantity',
+        value: value / divisor.factor,
+        dim: dimCombine(MONEY, divisor.dim, -1),
+        code: unifyCodes(code, divisor.code),
+      };
+    }
+    return { kind: 'quantity', value, dim: MONEY, code };
   }
 
   private peek(): Token | undefined {
@@ -528,26 +614,39 @@ class Parser {
         end = wordToken.to;
       }
       const unitToken = this.peek();
-      if (
-        unitToken?.type === 'ident' &&
-        unitToken.from - end <= 1 &&
-        UNITS[unitToken.name] !== undefined
-      ) {
+      const attached =
+        unitToken?.type === 'ident' && unitToken.from - end <= 1
+          ? this.resolveUnitOrCurrency(unitToken.name)
+          : null;
+      if (attached !== null && unitToken?.type === 'ident') {
         this.pos++;
-        const unit = UNITS[unitToken.name];
         const divisor = this.tryParseRateDivisor(unitToken.to);
         if (divisor) {
           return {
             kind: 'quantity',
-            value: (value * unit.factor) / divisor.spec.factor,
-            dim: dimCombine(unit.dim, divisor.spec.dim, -1),
+            value: (value * attached.factor) / divisor.factor,
+            dim: dimCombine(attached.dim, divisor.dim, -1),
+            code: unifyCodes(attached.code, divisor.code),
           };
         }
-        return { kind: 'quantity', value: value * unit.factor, dim: unit.dim };
+        return { kind: 'quantity', value: value * attached.factor, dim: attached.dim, code: attached.code };
       }
       return { kind: 'num', value };
     }
+    if (token.type === 'cursym') {
+      // Prefix symbol form: $320 (optionally $3 Billion).
+      this.pos++;
+      return this.parseMoneyAmount(token.code, token.to);
+    }
     if (token.type === 'ident') {
+      // Prefix code form: `kr 320`, `USD 100` — a currency name directly
+      // before a number wins over a same-named variable, like unit position.
+      const prefixCode = resolveCurrencyCode(token.name);
+      const next = this.tokens[this.pos + 1];
+      if (prefixCode !== null && next?.type === 'num' && next.from - token.to <= 1) {
+        this.pos++;
+        return this.parseMoneyAmount(prefixCode, token.to);
+      }
       this.pos++;
       if (this.peekOp() === '(') {
         this.pos++;
@@ -587,19 +686,19 @@ function requireDimless(q: Quantity): number {
 function evalNode(node: AstNode, env: ReadonlyMap<string, Quantity>): Quantity {
   switch (node.kind) {
     case 'num':
-      return { value: node.value, dim: DIMLESS };
+      return { value: node.value, dim: DIMLESS, code: null };
     case 'quantity':
-      return { value: node.value, dim: node.dim };
+      return { value: node.value, dim: node.dim, code: node.code };
     case 'var': {
       const value = env.get(node.name);
       if (value === undefined) throw new MathError(`undefined variable '${node.name}'`);
       return value;
     }
     case 'percent':
-      return { value: evalNode(node.operand, env).value / 100, dim: DIMLESS };
+      return { value: evalNode(node.operand, env).value / 100, dim: DIMLESS, code: null };
     case 'neg': {
       const operand = evalNode(node.operand, env);
-      return { value: -operand.value, dim: operand.dim };
+      return { value: -operand.value, dim: operand.dim, code: operand.code };
     }
     case 'group':
       return evalNode(node.operand, env);
@@ -610,7 +709,7 @@ function evalNode(node: AstNode, env: ReadonlyMap<string, Quantity>): Quantity {
         throw new MathError(`wrong arity for '${node.name}'`);
       }
       const args = node.args.map((arg) => requireDimless(evalNode(arg, env)));
-      return { value: fn.apply(args), dim: DIMLESS };
+      return { value: fn.apply(args), dim: DIMLESS, code: null };
     }
     case 'binary': {
       const left = evalNode(node.left, env);
@@ -620,22 +719,35 @@ function evalNode(node: AstNode, env: ReadonlyMap<string, Quantity>): Quantity {
       if ((node.op === '+' || node.op === '-') && node.right.kind === 'percent') {
         const fraction = evalNode(node.right, env).value;
         const scaled = node.op === '+' ? 1 + fraction : 1 - fraction;
-        return { value: left.value * scaled, dim: left.dim };
+        return { value: left.value * scaled, dim: left.dim, code: left.code };
       }
       const right = evalNode(node.right, env);
       switch (node.op) {
         case '+':
         case '-': {
           if (!dimEq(left.dim, right.dim)) throw new MathError('mismatched units');
+          const code = unifyCodes(left.code, right.code);
           const value = node.op === '+' ? left.value + right.value : left.value - right.value;
-          return { value, dim: left.dim };
+          return { value, dim: left.dim, code };
         }
         case '*':
-          return { value: left.value * right.value, dim: dimCombine(left.dim, right.dim, 1) };
+          return qty(
+            left.value * right.value,
+            dimCombine(left.dim, right.dim, 1),
+            unifyCodes(left.code, right.code)
+          );
         case '/':
-          return { value: left.value / right.value, dim: dimCombine(left.dim, right.dim, -1) };
+          return qty(
+            left.value / right.value,
+            dimCombine(left.dim, right.dim, -1),
+            unifyCodes(left.code, right.code)
+          );
         case '^':
-          return { value: Math.pow(requireDimless(left), requireDimless(right)), dim: DIMLESS };
+          return {
+            value: Math.pow(requireDimless(left), requireDimless(right)),
+            dim: DIMLESS,
+            code: null,
+          };
       }
     }
   }
@@ -653,7 +765,7 @@ export function evaluateExpression(
   const tokens = tokenize(src, 0);
   if (tokens === null || tokens.length === 0) return null;
   const quantities = new Map<string, Quantity>();
-  for (const [name, value] of env) quantities.set(name, { value, dim: DIMLESS });
+  for (const [name, value] of env) quantities.set(name, { value, dim: DIMLESS, code: null });
   try {
     const { node } = new Parser(tokens).parseTop();
     const result = evalNode(node, quantities);
@@ -683,10 +795,33 @@ export function formatResult(value: number): string {
   return (negative ? '-' : '') + grouped + (fracPart !== undefined ? '.' + fracPart : '');
 }
 
+/** Money renders like its marker was typed: symbols prefix (`$320`, `-$5`),
+ * word markers suffix (`320 kr`, `320 USD`). */
+function formatMoney(value: number, tag: string): string {
+  if (CURRENCY_SYMBOLS.has(tag)) {
+    return `${value < 0 ? '-' : ''}${tag}${formatResult(Math.abs(value))}`;
+  }
+  return `${formatResult(value)} ${tag}`;
+}
+
+/** Largest unit the magnitude reaches (`8 200 000` data → MB). */
+function pickByMagnitude(
+  family: ReadonlyArray<[label: string, factor: number]>,
+  value: number
+): [label: string, factor: number] {
+  const magnitude = Math.abs(value);
+  let best = family[0];
+  for (const entry of family) {
+    if (magnitude >= entry[1]) best = entry;
+  }
+  return best;
+}
+
 /**
  * Format a quantity for display, honoring an `in` conversion if given.
  * Returns null when there is no meaningful rendering (unknown dimension
- * combination, conversion dimension mismatch, hex/bin of a non-integer).
+ * combination, conversion dimension or currency mismatch, hex/bin of a
+ * non-integer).
  */
 function formatQuantity(q: Quantity, conversion: Conversion | null): string | null {
   if (conversion?.type === 'radix') {
@@ -699,17 +834,42 @@ function formatQuantity(q: Quantity, conversion: Conversion | null): string | nu
   }
   if (conversion?.type === 'unit') {
     if (!dimEq(q.dim, conversion.dim)) return null;
+    try {
+      unifyCodes(q.code, conversion.code);
+    } catch {
+      return null;
+    }
     return `${formatResult(q.value / conversion.factor)} ${conversion.text}`;
   }
   if (isDimless(q.dim)) return formatResult(q.value);
-  const family = DISPLAY_FAMILIES.get(dimKey(q.dim));
-  if (family === undefined) return null;
-  const magnitude = Math.abs(q.value);
-  let best = family[0];
-  for (const entry of family) {
-    if (magnitude >= entry[1]) best = entry;
+  if (q.dim.currency === 0) {
+    const family = DISPLAY_FAMILIES.get(dimKey(q.dim));
+    if (family === undefined) return null;
+    const best = pickByMagnitude(family, q.value);
+    return `${formatResult(q.value / best[1])} ${best[0]}`;
   }
-  return `${formatResult(q.value / best[1])} ${best[0]}`;
+  const residual = { ...q.dim, currency: 0 };
+  if (q.dim.currency === 1) {
+    // Plain money, rendered like the marker was typed: `$320`, `320 kr`.
+    if (isDimless(residual)) return formatMoney(q.value, q.code!);
+    // Price per something: scale the denominator so the number reads well —
+    // 1e-7 NOK per byte becomes `100 NOK/GB`.
+    const family = DISPLAY_FAMILIES.get(dimKey(dimCombine(DIMLESS, residual, -1)));
+    if (family === undefined) return null;
+    let best = family[0];
+    for (const entry of family) {
+      if (Math.abs(q.value) * entry[1] < 1000) best = entry;
+    }
+    return `${formatMoney(q.value * best[1], q.code!)}/${best[0]}`;
+  }
+  if (q.dim.currency === -1) {
+    // Something per money: `32GB / 3200 NOK` becomes `10 MB/NOK`.
+    const family = DISPLAY_FAMILIES.get(dimKey(residual));
+    if (family === undefined) return null;
+    const best = pickByMagnitude(family, q.value);
+    return `${formatResult(q.value / best[1])} ${best[0]}/${q.code}`;
+  }
+  return null;
 }
 
 // --- Document analysis -------------------------------------------------------
@@ -733,7 +893,7 @@ const CONSTANTS: ReadonlyArray<[string, number]> = [
 export function analyzeDocument(lines: readonly string[]): Array<MathLineResult | null> {
   const results: Array<MathLineResult | null> = new Array(lines.length).fill(null);
   const env = new Map<string, Quantity>();
-  for (const [name, value] of CONSTANTS) env.set(name, { value, dim: DIMLESS });
+  for (const [name, value] of CONSTANTS) env.set(name, { value, dim: DIMLESS, code: null });
 
   // Frontmatter: only a leading '---' with a matching closer counts
   // (same semantics as tagPlugin's isInFrontmatter).

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+});


### PR DESCRIPTION
## What

Inline math in the editor, modeled on Apple Notes' math feature: `Name = expression` lines define variables (highlighted in the editor), and a trailing `=` shows the computed result as a read-only ghost decoration after the `=` — recomputed live from the note text and **never written to the note or disk**.

```
Params = 32 Billion
BytesPerParam = 4b # AWQ 4-bit
ModelSize = Params × BytesPerParam + 20% = ⟨19.2 GB⟩
32GB / 3200 NOK = ⟨10 MB/NOK⟩
```

## Language

- Arithmetic: `+ - × ÷ * / ^`, parentheses, unary minus, percentages (`X + 20%` = X×1.2 Apple-style)
- Numbers: decimals, thousands-separated input (`16 000 000 000`), hex/bin literals (`0xFF`, `0b1010`), `k/M/G/T` scale suffixes, word multipliers (`32 Billion`)
- **Units with dimensional analysis**: data (SI + IEC + bits), time, energy, power, length, mass, frequency — `6kJ/s = ⟨6 kW⟩`, `8MB / 2s = ⟨4 MB/s⟩`, auto-scaled display; mismatches (`8MB + 2s`) fail silently
- **Currencies**: markers as typed (`$`, `€`, `£`, `¥`, `kr`, any ISO code) with strict matching — no exchange-rate assumptions; `$ = USD`-style alias lines assign notation per note
- **Conversions**: `8MB in KiB`, `90min in h`, `255 in hex`, `Price in NOK/GB`
- Functions (trig in degrees), constants `pi`/`e` (shadowable), `#` comments
- Anything that doesn't fully parse **and** evaluate is left completely untouched — `Deadline = Friday` stays prose; headings, code fences, checkboxes, and tags are unaffected

## Implementation

- `src/utils/mathEvaluator.ts` — pure tokenizer → recursive-descent parser → dimensional evaluator → formatter; zero deps, no CM imports
- `src/components/editor/mathPlugin.ts` — CM6 ViewPlugin following the tagPlugin/imagePlugin patterns: `Decoration.mark` for variable names/refs, `Decoration.widget` (`side: 1`, `ignoreEvent`) for ghost results; derive-and-render only, no dispatches, undo history untouched; works on desktop and iOS
- Adds **vitest** as the repo's first test setup (`npm test`): 74 unit tests over the evaluator grammar and edge cases

## Verification

- 74 unit tests green; `tsc -b` and lint clean (the SettingsModal lint error pre-exists on main)
- Rendered-surface checks in headless Chromium: mounted the real plugin in a real EditorView, verified decorations, live recompute on edit, doc-integrity (decorations never mutate text), and coexistence with tag highlighting
- Also adds `.claude/skills/verify/SKILL.md` documenting the headless verification recipe