### PR TITLE
fix: sync Nextcloud URL input without setState-in-effect

### DIFF
--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -203,7 +203,6 @@ export function MarkdownEditor({ className }: MarkdownEditorProps) {
   // CodeMirror extension array on every keystroke — activeNote identity
   // changes whenever notes content updates, but extensions only need to
   // change when the underlying file path does.
-  // eslint-disable-next-line react-hooks/preserve-manual-memoization
   const extensions: Extension[] = useMemo(() => {
     const exts: Extension[] = [
       listContinuationKeymap,

--- a/src/components/layout/SettingsModal.tsx
+++ b/src/components/layout/SettingsModal.tsx
@@ -61,6 +61,14 @@ export function SettingsModal() {
   const [editingName, setEditingName] = useState('');
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<string | null>(null);
   const [nextcloudUrl, setNextcloudUrl] = useState(settings.sync.serverUrl || '');
+  // Re-sync the input when the stored URL changes (connect, disconnect,
+  // profile switch) — adjusted during render instead of in an effect, per
+  // https://react.dev/learn/you-might-not-need-an-effect
+  const [prevServerUrl, setPrevServerUrl] = useState(settings.sync.serverUrl);
+  if (prevServerUrl !== settings.sync.serverUrl) {
+    setPrevServerUrl(settings.sync.serverUrl);
+    setNextcloudUrl(settings.sync.serverUrl || '');
+  }
 
   // AI settings state
   const [models, setModels] = useState<string[]>([]);
@@ -69,10 +77,6 @@ export function SettingsModal() {
   const showAiSettings = !isIOS;
   const showUpdateSettings = !isIOS;
   const showStorageSettings = !isIOS;
-
-  useEffect(() => {
-    setNextcloudUrl(settings.sync.serverUrl || '');
-  }, [settings.sync.serverUrl]);
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {


### PR DESCRIPTION
Fixes #142.

## What

`npm run lint` failed on `main` with a `react-hooks/set-state-in-effect` error: the settings modal re-synced its local Nextcloud server URL input state from the settings store inside a `useEffect`.

Replaced the effect with React's documented alternative — adjusting state during render behind a previous-value guard ([You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect)):

```tsx
const [prevServerUrl, setPrevServerUrl] = useState(settings.sync.serverUrl);
if (prevServerUrl !== settings.sync.serverUrl) {
  setPrevServerUrl(settings.sync.serverUrl);
  setNextcloudUrl(settings.sync.serverUrl || '');
}
```

Trigger semantics are identical to the old effect (fires exactly when the stored `serverUrl` value changes: connect, disconnect, profile switch, cross-window update), minus one commit's worth of stale-value flash. In-progress typing is untouched, same as before.

Also removed the now-unused `react-hooks/preserve-manual-memoization` disable directive in the markdown editor (the issue's optional cleanup), so lint is fully clean — zero errors, zero warnings.

## Acceptance criteria from #142

- [x] `npm run lint` exits 0 with zero errors — verified, also zero warnings
- [x] No new `eslint-disable` comments — one *removed*, none added
- [x] Input reflects an externally-updated stored `serverUrl` while the modal is open — same value-change trigger as the old effect, applied one render earlier
- [x] Editing the URL field and connecting still works — verified by construction (the `onChange` → `setNextcloudUrl` path and `handleConnectNextcloud` are untouched); no component-level test exists for the modal, and the issue scoped adding test infra out

## Verification

- `npm run lint` — ✅ 0 problems (was 1 error + 1 warning)
- `npm test` — ✅ 76/76 passed
- `npm run build` (`tsc -b && vite build`) — ✅ pass
